### PR TITLE
Added the FAQ content, with a link to the markdown file

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -8,12 +8,12 @@ Yes, the summit is organised by individual people in the WebAssembly communitty,
 
 The organizers are (in alphabetical order):
 
-* Aaron Turner [(@torch2424)](https://twitter.com/torch2424)
-* Ashley Williams [(@ag_dubs)](https://twitter.com/ag_dubs)
-* Michael Hablich [(@MHablich)](https://twitter.com/MHablich)
-* Surma [(@DasSurma)](https://twitter.com/DasSurma)
-* Thomas Tränkler [(@ttraenkler)](https://twitter.com/ttraenkler)
-* Till Schneidereit [(@tschneidereit)](https://twitter.com/tschneidereit)
+* Aaron Turner
+* Ashley Williams
+* Michael Hablich
+* Surma
+* Thomas Tränkler
+* Till Schneidereit
 
 With some help of some other awesome folks!
 
@@ -32,3 +32,4 @@ Yes, the talks will be uploaded to Youtube.
 ## Does the event have a Code of Conduct?
 
 Yes, please see the [Code of Conduct here](https://github.com/WebAssemblySummit/webassemblysummit.github.io/blob/dev/CODE_OF_CONDUCT.md).
+

--- a/FAQ.md
+++ b/FAQ.md
@@ -1,0 +1,34 @@
+# Frequently Asked Questions
+
+## Is this a community event?
+
+Yes, the summit is organised by individual people in the WebAssembly communitty, and at the time of writing sponsored by Google and Mozilla. 
+
+## Who is organizing?
+
+The organizers are (in alphabetical order):
+
+* Aaron Turner [(@torch2424)](https://twitter.com/torch2424)
+* Ashley Williams [(@ag_dubs)](https://twitter.com/ag_dubs)
+* Michael Hablich [(@MHablich)](https://twitter.com/MHablich)
+* Surma [(@DasSurma)](https://twitter.com/DasSurma)
+* Thomas Tränkler [(@ttraenkler)](https://twitter.com/ttraenkler)
+* Till Schneidereit [(@tschneidereit)](https://twitter.com/tschneidereit)
+
+With some help of some other awesome folks!
+
+## Who can I contact?
+
+To get in contact with the summit organizers, please send an email to: [wasm-summit-2020@chromium.org](mailto:wasm-summit-2020@chromium.org).
+
+## Will it be livestreamed?
+
+Yes, the summit will be livestreamed on Youtube.
+
+## Will the talks be recorded?
+
+Yes, the talks will be uploaded to Youtube.
+
+## Does the event have a Code of Conduct?
+
+Yes, please see the [Code of Conduct here](https://github.com/WebAssemblySummit/webassemblysummit.github.io/blob/dev/CODE_OF_CONDUCT.md).

--- a/FAQ.md
+++ b/FAQ.md
@@ -2,7 +2,7 @@
 
 ## Is this a community event?
 
-Yes, the summit is organised by individual people in the WebAssembly communitty, and at the time of writing sponsored by Google and Mozilla. 
+Yes, the summit is organised by individual people in the WebAssembly community, and at the time of writing sponsored by Google and Mozilla. 
 
 ## Who is organizing?
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -52,9 +52,10 @@ const LandingPage: FC = () => (
     </OnelinerCentered>
 
     <Footer>
-      <a href="mailto:wasm-summit-2020@chromium.org">wasm-summit-2020@chromium.org</a>
-      <a href="https://github.com/WebAssemblySummit/webassemblysummit.github.io/blob/dev/CODE_OF_CONDUCT.md">Code of conduct</a>
-      <a href="https://twitter.com/search?q=%23WasmSummit&src=typed_query">#WasmSummit</a>
+      <NoBreak><a href="mailto:wasm-summit-2020@chromium.org">wasm-summit-2020@chromium.org</a></NoBreak>
+      <NoBreak><a href="https://github.com/WebAssemblySummit/webassemblysummit.github.io/blob/dev/FAQ.md">FAQ</a></NoBreak>
+      <NoBreak><a href="https://github.com/WebAssemblySummit/webassemblysummit.github.io/blob/dev/CODE_OF_CONDUCT.md">Code of conduct</a></NoBreak>
+      <NoBreak><a href="https://twitter.com/search?q=%23WasmSummit&src=typed_query">#WasmSummit</a></NoBreak>
     </Footer>
   </Container>
 );
@@ -219,6 +220,10 @@ const Footer = styled.footer`
   color: rgba(255, 255, 255, 0.7);
   margin: 2vh 0;
   font-size: 1.1rem;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
 
   a,
   a:visited {


### PR DESCRIPTION
closes #31 
relates to #24 

This adds a FAQ document to the repo (Adding the content), and adds a link to this document from the website 😄 

<img width="1419" alt="Screen Shot 2019-12-09 at 8 17 21 AM" src="https://user-images.githubusercontent.com/1448289/70482853-92996180-1a9b-11ea-8672-e777cc39fc82.png">
<img width="510" alt="Screen Shot 2019-12-09 at 8 17 29 AM" src="https://user-images.githubusercontent.com/1448289/70482854-92996180-1a9b-11ea-911b-d5507fa9b831.png">
<img width="322" alt="Screen Shot 2019-12-09 at 8 17 35 AM" src="https://user-images.githubusercontent.com/1448289/70482856-92996180-1a9b-11ea-9015-9e91c9b73f22.png">
