### PR TITLE
Removed the twitter links from Organizers

### DIFF
--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -38,12 +38,12 @@ const AboutPage: FC = () => (
                 <Faq heading="Who is organizing?">
                     The organizers are (in alphabetical order):
                     <ul>
-                        <li>Aaron Turner (<a href="https://twitter.com/torch2424">@torch2424</a>)</li>
-                        <li>Ashley Williams (<a href="https://twitter.com/ag_dubs">@ag_dubs</a>)</li>
-                        <li>Michael Hablich (<a href="https://twitter.com/MHablich">@MHablich</a>)</li>
-                        <li>Surma (<a href="https://twitter.com/DasSurma">@DasSurma</a>)</li>
-                        <li>Thomas Tränkler  (<a href="https://twitter.com/ttraenkler">@ttraenkler</a>)</li>
-                        <li>Till Schneidereit (<a href="https://twitter.com/tschneidereit">@tschneidereit</a>)</li>
+                        <li>Aaron Turner</li>
+                        <li>Ashley Williams</li>
+                        <li>Michael Hablich</li>
+                        <li>Surma</li>
+                        <li>Thomas Tränkler</li>
+                        <li>Till Schneidereit</li>
                     </ul>
 
                     With some help of some other awesome folks!


### PR DESCRIPTION
relates to #32 

I think when we updated / merged #30 using content of an older commit of mine, we left in the twitter links to the organizers. I removed them because we didn't want to encourage attendees to contact organizers directly, but rather to try and funnel everyone through the wasm-summit email 😄 

<img width="988" alt="Screen Shot 2019-12-11 at 11 10 31 AM" src="https://user-images.githubusercontent.com/1448289/70652257-2cc9e880-1c07-11ea-8fc7-013db2462383.png">
