### PR TITLE
bugfix for unclickable burger menu on ios

### DIFF
--- a/components/NavBar/index.tsx
+++ b/components/NavBar/index.tsx
@@ -52,9 +52,11 @@ const NavBar: FC<{
             </Button>
           ))}
         </NavItems>
-        <BurgerButton onClick={() => setOpen(!open)}>
-          <IoMdMenu size={35}></IoMdMenu>
-        </BurgerButton>
+        <A onClick={() => setOpen(!open)}>
+          <BurgerButton>
+            <IoMdMenu size={35}></IoMdMenu>
+          </BurgerButton>
+        </A>
       </Box>
       <Popup open={open} backgroundColor={backgroundColor}>
         {textNavItems.map(({ label, link }) =>


### PR DESCRIPTION
although it was working on my iPhone connecting to the production build of localhost, when deployed on github i cant click the menu burger. this PR attempts to fix this wrapping it in an <a> tag.