### PR TITLE
page accessibility, headlines, and layout

### DIFF
--- a/data/about.tsx
+++ b/data/about.tsx
@@ -61,7 +61,7 @@ export const faq: {
       <>
         If you need to get in contact with the organizers for whatever reason,
         please send an email to{" "}
-        <a href="mailto:wasm-summit-2020@chromium.org">
+        <a href="mailto:wasm-summit-2020@chromium.org" rel="noreferrer">
           wasm-summit-2020@chromium.org
         </a>
         . <br />

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -63,6 +63,7 @@ export default class extends App {
           <meta name="viewport" content="width=device-width, initial-scale=1" />
           <meta name="description" content="WebAssembly Summit 2020" />
           <link rel="shortcut icon" type="image/x-icon" href="favicon.ico" />
+          <link href="https://fonts.googleapis.com" rel="preconnect" />
           <link
             href="https://fonts.googleapis.com/css?family=IBM+Plex+Sans&display=swap"
             rel="stylesheet"

--- a/pages/about/index.tsx
+++ b/pages/about/index.tsx
@@ -1,8 +1,8 @@
 import { FC, ReactNode } from "react";
 import styled from "styled-components";
+import { navbarBlue } from "../../components/colors";
 import NavBar from "../../components/NavBar";
 import { faq } from "../../data/about";
-import { navbarBlue } from "../../components/colors";
 
 const title = "About";
 
@@ -16,13 +16,15 @@ const AboutPage: FC = () => (
       bottom
     />
     <Faq id="faq">
-      <Headline>Frequently Asked Questions</Headline>
-      {faq.map(({ question, answer }) => (
-        <FaqItem key={question}>
-          <Question>{question}</Question>
-          <Answer>{answer}</Answer>
-        </FaqItem>
-      ))}
+      <Headline>{title}</Headline>
+      <Questions>
+        {faq.map(({ question, answer }) => (
+          <QuestionAnswerPair key={question}>
+            <Question>{question}</Question>
+            <Answer>{answer}</Answer>
+          </QuestionAnswerPair>
+        ))}
+      </Questions>
     </Faq>
   </>
 );
@@ -39,8 +41,27 @@ export const Background = styled.div`
   z-index: -1;
 `;
 
+export const Headline = styled.h1`
+  font-size: 3em;
+  margin-top: 3vh;
+  margin-bottom: 0vh;
+  padding: 15px;
+`;
+
 const Faq = styled.div`
-  padding: 7vh 5%;
+  padding: 3vh 5vw;
+  color: white;
+  a {
+    color: white;
+    text-decoration: underline;
+    &:visited {
+      color: white;
+      text-decoration: underline;
+    }
+  }
+`;
+
+const Questions = styled.div`
   background-color: ${(props: { primary?: boolean }) =>
     props.primary ? "#fff" : "transparent"};
   box-shadow: ${(props: { primary?: boolean }) =>
@@ -60,18 +81,14 @@ const Faq = styled.div`
   }
 `;
 
-const Headline = styled.h1`
-  font-size: 2.5em;
-`;
-
-const FaqItem = styled.div`
+const QuestionAnswerPair = styled.div`
   break-inside: avoid;
 `;
 
 const Question = styled.h2`
   font-size: 1.5em;
   margin: 0 25px 0 0;
-  padding: 15px 15px;
+  padding: 15px;
   font-weight: 700;
   border-bottom: 3px solid rgba(255, 255, 255, 0.4);
   text-shadow: 2px 4px 5px hsla(237, 80%, 35%, 0.3);

--- a/pages/about/index.tsx
+++ b/pages/about/index.tsx
@@ -8,20 +8,28 @@ const title = "About";
 
 const AboutPage: FC = () => (
   <>
-    <BackgroundLayer></BackgroundLayer>
+    <Background />
     <NavBar
       title={title}
       currentPage="About"
       backgroundColor={navbarBlue}
       bottom
     />
-    <Faq />
+    <Faq id="faq">
+      <Headline>Frequently Asked Questions</Headline>
+      {faq.map(({ question, answer }) => (
+        <FaqItem key={question}>
+          <Question>{question}</Question>
+          <Answer>{answer}</Answer>
+        </FaqItem>
+      ))}
+    </Faq>
   </>
 );
 
 export default AboutPage;
 
-export const BackgroundLayer = styled.div`
+export const Background = styled.div`
   background-color: hsla(237, 60%, 48%, 0.6);
   position: fixed;
   top: 0;
@@ -31,17 +39,7 @@ export const BackgroundLayer = styled.div`
   z-index: -1;
 `;
 
-const Faq: FC = () => (
-  <FaqBox id="faq">
-    {faq.map(({ question, answer }) => (
-      <FaqItem key={question} question={question}>
-        {answer}
-      </FaqItem>
-    ))}
-  </FaqBox>
-);
-
-const FaqBox = styled.div`
+const Faq = styled.div`
   padding: 7vh 5%;
   background-color: ${(props: { primary?: boolean }) =>
     props.primary ? "#fff" : "transparent"};
@@ -62,21 +60,19 @@ const FaqBox = styled.div`
   }
 `;
 
-const FaqItem: FC<{ question: string; children: ReactNode }> = ({
-  question: heading,
-  children
-}) => (
-  <div style={{ breakInside: "avoid" }}>
-    <Question bold>{heading}</Question>
-    <Answer>{children}</Answer>
-  </div>
-);
+const Headline = styled.h1`
+  font-size: 2.5em;
+`;
 
-const Question = styled.div`
+const FaqItem = styled.div`
+  break-inside: avoid;
+`;
+
+const Question = styled.h2`
   font-size: 1.5em;
   margin: 0 25px 0 0;
   padding: 15px 15px;
-  font-weight: ${(props: { bold?: boolean }) => (props.bold ? 700 : "normal")};
+  font-weight: 700;
   border-bottom: 3px solid rgba(255, 255, 255, 0.4);
   text-shadow: 2px 4px 5px hsla(237, 80%, 35%, 0.3);
 `;

--- a/pages/speakers/index.tsx
+++ b/pages/speakers/index.tsx
@@ -22,6 +22,7 @@ const SpeakersPage: FC = () => (
       backgroundColor={navbarBlue}
       bottom
     />
+    <Headline>{title}</Headline>
     <Speakers id="speakers">
       {speakers.map((speaker, index) => (
         <Speaker key={speaker.name + index} profile={speaker} />
@@ -31,6 +32,18 @@ const SpeakersPage: FC = () => (
 );
 
 export default SpeakersPage;
+
+export const Headline = styled.h1`
+  font-size: 2.5em;
+  margin-top: 3vh;
+  margin-bottom: 2vh;
+  padding: 0 0px;
+  margin-left: 4vw;
+  @media screen and (max-width: 663px) {
+    text-align: center;
+    margin-left: 0;
+  }
+`;
 
 const Speaker: FC<{ profile: SpeakerProfile }> = ({ profile }) => (
   <SpeakerCard>
@@ -92,6 +105,14 @@ const SpeakerCard = styled.div`
   @media (max-width: 1280px) {
     width: 300px;
   }
+
+  @media screen and (max-width: 663px) {
+    width: 400px;
+  }
+
+  @media screen and (max-width: 450px) {
+    width: 300px;
+  }
 `;
 
 const Background = styled.div`
@@ -110,8 +131,8 @@ const Background = styled.div`
 const Speakers = styled.div`
   margin: 0;
   padding: 25px;
+  padding-top: 0px;
   padding-bottom: 100px;
-  padding-top: 50px;
   /* display: flex;
   flex-direction: row;
   flex-wrap: wrap;

--- a/pages/speakers/index.tsx
+++ b/pages/speakers/index.tsx
@@ -15,32 +15,32 @@ export type SpeakerProfile = {
 
 const SpeakersPage: FC = () => (
   <>
-    <Sandbox />
+    <Background />
     <NavBar
       title={title}
       currentPage="Speakers"
       backgroundColor={navbarBlue}
       bottom
     />
-    <ContentContainer id="about">
+    <Speakers id="speakers">
       {speakers.map((speaker, index) => (
         <Speaker key={speaker.name + index} profile={speaker} />
       ))}
-    </ContentContainer>
+    </Speakers>
   </>
 );
 
 export default SpeakersPage;
 
 const Speaker: FC<{ profile: SpeakerProfile }> = ({ profile }) => (
-  <SectionBody>
+  <SpeakerCard>
     <img src={profile.picture}></img>
-    <SectionHeader bold>{profile.name}</SectionHeader>
-    <Bio>{profile.bio}</Bio>
-  </SectionBody>
+    <SpeakerName bold>{profile.name}</SpeakerName>
+    <SpeakerSummary>{profile.bio}</SpeakerSummary>
+  </SpeakerCard>
 );
 
-const Bio = styled.div`
+const SpeakerSummary = styled.div`
   padding: 20px 25px;
   background: hsl(239, 50%, 25%);
   height: 140px;
@@ -55,7 +55,7 @@ const Bio = styled.div`
   color: rgba(255, 255, 255, 0.8);
 `;
 
-const SectionHeader = styled.div`
+const SpeakerName = styled.div`
   font-size: 1.5em;
   margin: 0;
   padding: 5px 15px;
@@ -67,7 +67,7 @@ const SectionHeader = styled.div`
   color: white;
 `;
 
-const SectionBody = styled.div`
+const SpeakerCard = styled.div`
   font-size: 1.1em;
   margin: 2.5% 1%;
   color: black;
@@ -94,7 +94,7 @@ const SectionBody = styled.div`
   }
 `;
 
-const Sandbox = styled.div`
+const Background = styled.div`
   display: flex;
   position: fixed;
   top: 0;
@@ -107,7 +107,7 @@ const Sandbox = styled.div`
   z-index: -1;
 `;
 
-const ContentContainer = styled.div`
+const Speakers = styled.div`
   margin: 0;
   padding: 25px;
   padding-bottom: 100px;


### PR DESCRIPTION
- added headline to about and speaker page #52 #61
- made headlines h1 and h2 and added alt image text for accessibility #55, #71
- refined narrow screen speaker card layout #49 
- contact email link noreferrer added (lighthouse report) #69 
- preconnect for faster font loading  #52
- cleaned up the code a bit