### PR TITLE
Feature/73 iphone navbar bug

### DIFF
--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -341,6 +341,21 @@ const BottomBox = styled.div`
     box-shadow: inset 0px 5px 10px hsla(256, 91%, 10%, 0.3);
     justify-content: center;
   }
+
+  /* iphone X, iPhone XS, iPhone 11 Pro */
+  @media only screen and (min-device-width: 375px) and (max-device-height: 812px) and (-webkit-device-pixel-ratio: 3) {
+    padding-bottom: 50px;
+  }
+
+  /* iphone XR, iPhone 11 */
+  @media only screen and (min-device-width: 414px) and (max-device-height: 896px) and (-webkit-device-pixel-ratio: 2) {
+    padding-bottom: 50px;
+  }
+
+  /* iphone XS Max, iPhone 11 Pro max */
+  @media only screen and (min-device-width: 414px) and (max-device-height: 896px) and (-webkit-device-pixel-ratio: 3) {
+    padding-bottom: 50px;
+  }
 `;
 
 const TopBox = styled.div`

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -12,6 +12,7 @@ import { IconType } from "react-icons/lib/cjs";
 import { IoMdMenu, IoMdClose } from "react-icons/io";
 import { GoPerson } from "react-icons/go";
 import Header from "./Header";
+import { useScrollDirection, UP } from "../hooks/useScrollDirection";
 
 const NavBar: FC<{
   backgroundColor?: string;
@@ -20,12 +21,19 @@ const NavBar: FC<{
   bottom?: boolean;
 }> = ({ title, currentPage, bottom, backgroundColor }) => {
   const [open, setOpen] = useState(false);
+  const scrollDirection = useScrollDirection();
   const Box = bottom ? BottomBox : TopBox;
   const onClick = () => setOpen(!open);
 
   return (
     <>
-      <Box backgroundColor={backgroundColor}>
+      <Box
+        backgroundColor={backgroundColor}
+        style={{
+          transform: scrollDirection == UP ? "none" : "translateY(100%)",
+          transition: "150ms"
+        }}
+      >
         <Link href="/" as="/" passHref>
           <a>
             <HomeButton>
@@ -343,23 +351,23 @@ const BottomBox = styled.div`
   }
 
   /* iphone X, iPhone XS, iPhone 11 Pro */
-  @media only screen and (min-device-width: 375px) and (max-device-height: 812px) and (-webkit-device-pixel-ratio: 3) {
+  /*  @media only screen and (min-device-width: 375px) and (max-device-height: 812px) and (-webkit-device-pixel-ratio: 3) {
     padding-bottom: 50px;
-  }
+  } */
 
   /* iphone XR, iPhone 11 */
-  @media only screen and (min-device-width: 414px) and (max-device-height: 896px) and (-webkit-device-pixel-ratio: 2) {
+  /*  @media only screen and (min-device-width: 414px) and (max-device-height: 896px) and (-webkit-device-pixel-ratio: 2) {
     padding-bottom: 50px;
-  }
+  } */
 
   /* iphone XS Max, iPhone 11 Pro max */
-  @media only screen and (min-device-width: 414px) and (max-device-height: 896px) and (-webkit-device-pixel-ratio: 3) {
+  /*  @media only screen and (min-device-width: 414px) and (max-device-height: 896px) and (-webkit-device-pixel-ratio: 3) {
     padding-bottom: 50px;
-  }
+  } */
 
-  @media only screen and (max-height: 414px) and (orientation: landscape) {
+  /*   @media only screen and (max-height: 414px) and (orientation: landscape) {
     display: none;
-  }
+  } */
 `;
 
 const TopBox = styled.div`

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -356,6 +356,10 @@ const BottomBox = styled.div`
   @media only screen and (min-device-width: 414px) and (max-device-height: 896px) and (-webkit-device-pixel-ratio: 3) {
     padding-bottom: 50px;
   }
+
+  @media only screen and (max-height: 414px) and (orientation: landscape) {
+    display: none;
+  }
 `;
 
 const TopBox = styled.div`

--- a/hooks/useScrollDirection.ts
+++ b/hooks/useScrollDirection.ts
@@ -1,14 +1,14 @@
 import { useEffect, useState } from "react";
 
-const SCROLL_UP = "up";
-const SCROLL_DOWN = "down";
+export const UP = "up";
+export const DOWN = "down";
 
 type ScrollDirection = "up" | "down";
 
 export const useScrollDirection = ({
-  initialDirection,
-  thresholdPixels,
-  off
+  initialDirection = UP,
+  thresholdPixels = 5,
+  off = false
 }: {
   initialDirection?: ScrollDirection;
   thresholdPixels?: number;
@@ -30,7 +30,7 @@ export const useScrollDirection = ({
         return;
       }
 
-      setScrollDir(scrollY > lastScrollY ? SCROLL_DOWN : SCROLL_UP);
+      setScrollDir(scrollY > lastScrollY ? DOWN : UP);
       lastScrollY = scrollY > 0 ? scrollY : 0;
       ticking = false;
     };

--- a/hooks/useScrollDirection.ts
+++ b/hooks/useScrollDirection.ts
@@ -1,0 +1,57 @@
+import { useEffect, useState } from "react";
+
+const SCROLL_UP = "up";
+const SCROLL_DOWN = "down";
+
+type ScrollDirection = "up" | "down";
+
+export const useScrollDirection = ({
+  initialDirection,
+  thresholdPixels,
+  off
+}: {
+  initialDirection?: ScrollDirection;
+  thresholdPixels?: number;
+  off?: boolean;
+} = {}) => {
+  const [scrollDir, setScrollDir] = useState(initialDirection);
+
+  useEffect(() => {
+    const threshold = thresholdPixels || 0;
+    let lastScrollY = window.pageYOffset;
+    let ticking = false;
+
+    const updateScrollDir = () => {
+      const scrollY = window.pageYOffset;
+
+      if (Math.abs(scrollY - lastScrollY) < threshold) {
+        // We haven't exceeded the threshold
+        ticking = false;
+        return;
+      }
+
+      setScrollDir(scrollY > lastScrollY ? SCROLL_DOWN : SCROLL_UP);
+      lastScrollY = scrollY > 0 ? scrollY : 0;
+      ticking = false;
+    };
+
+    const onScroll = () => {
+      if (!ticking) {
+        window.requestAnimationFrame(updateScrollDir);
+        ticking = true;
+      }
+    };
+
+    /**
+     * Bind the scroll handler if `off` is set to false.
+     * If `off` is set to true reset the scroll direction.
+     */
+    !off
+      ? window.addEventListener("scroll", onScroll)
+      : setScrollDir(initialDirection);
+
+    return () => window.removeEventListener("scroll", onScroll);
+  }, [initialDirection, thresholdPixels, off]);
+
+  return scrollDir;
+};


### PR DESCRIPTION
Fixes #73 

On these models when scrolling down the browser bottom button bar disappears but when trying to click on the wasm summit navbar, it pops back up again. instead, i hide the summit navbar on scroll down and it only comes back when scrolling up - this way both more content is visible and the bug is solved.