### PR TITLE
disabled cleaning outdated files on deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,4 +40,4 @@ jobs:
           BASE_BRANCH: dev
           BRANCH: master
           FOLDER: out
-          CLEAN: true
+          CLEAN: false

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,4 +40,4 @@ jobs:
           BASE_BRANCH: dev
           BRANCH: master
           FOLDER: out
-          CLEAN: false
+          CLEAN: true

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,6 @@
 // next.config.js
-const withOffline = require("next-offline");
+/* const withOffline = require("next-offline"); */
 
 const nextConfig = {};
 
-module.exports = withOffline(nextConfig);
+module.exports = {}; /* withOffline(nextConfig); */

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,6 +2,19 @@ import App from "next/app";
 import Head from "next/head";
 import { createGlobalStyle } from "styled-components";
 
+if ("serviceWorker" in navigator) {
+  window.addEventListener("load", function() {
+    navigator.serviceWorker.getRegistrations().then(registrations => {
+      for (let registration of registrations) {
+        registration.unregister().then(bool => {
+          console.log("unregister: ", bool);
+        });
+      }
+      window.location.reload();
+    });
+  });
+}
+
 // pages/_app.tsx
 const GlobalStyles = createGlobalStyle`
   @import url('https://fonts.googleapis.com/css?family=IBM+Plex+Sans:400,700&display=swap');


### PR DESCRIPTION
As a workaround to the service worker looking to precache outdated assets #87 and due to the fact that this is an open issue for the package we're using (next-offline), we need to disable cleaning the build assets in the master branch on each deployment until the issue is solved. 