### PR TITLE
Fixing unbalanced speaker page layout

### DIFF
--- a/components/SpeakerCard.tsx
+++ b/components/SpeakerCard.tsx
@@ -3,6 +3,9 @@ import styled from "styled-components";
 import { wasmPurple } from "./colors";
 
 export const SpeakerSummary = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
   padding: 15px 30px 30px 30px;
   background: hsl(239, 50%, 25%);
   height: 140px;
@@ -91,6 +94,7 @@ export const Title = styled.h2`
   font-weight: bold;
   margin: 0px 0;
   padding: 0;
+  flex: 1;
   color: rgba(255, 255, 255, 0.85);
 
   @media screen and (max-width: 1024px) {

--- a/components/SpeakerCard.tsx
+++ b/components/SpeakerCard.tsx
@@ -89,7 +89,7 @@ const SpeakerCard = styled.div`
 `;
 
 export const Title = styled.h2`
-  font-size: 1.5em;
+  font-size: 1.4em;
   line-height: 1.4;
   font-weight: bold;
   margin: 0px 0;
@@ -98,7 +98,7 @@ export const Title = styled.h2`
   color: rgba(255, 255, 255, 0.85);
 
   @media screen and (max-width: 1024px) {
-    font-size: 1.5em;
+    font-size: 1.4em;
   }
 `;
 

--- a/components/SpeakerCard.tsx
+++ b/components/SpeakerCard.tsx
@@ -7,14 +7,14 @@ export const SpeakerSummary = styled.div`
   background: hsl(239, 50%, 25%);
   height: 140px;
   line-height: 1.8;
-  font-size: 0.78em;
+  font-size: 1em;
 
   p {
     color: rgba(255, 255, 255, 0.5);
     margin: 0;
     margin-bottom: 5px;
     font-weight: normal;
-    font-size: 1.4em;
+    font-size: 1.8em;
     padding: 0;
   }
 
@@ -86,7 +86,7 @@ const SpeakerCard = styled.div`
 `;
 
 export const Title = styled.h2`
-  font-size: 1.6em;
+  font-size: 1.5em;
   line-height: 1.4;
   font-weight: bold;
   margin: 0px 0;

--- a/components/SpeakerCard.tsx
+++ b/components/SpeakerCard.tsx
@@ -41,7 +41,7 @@ export const SpeakerName = styled.div`
   color: white;
   margin: 0;
   margin: 0;
-  padding: 8px 15px;
+  padding: 10px 15px;
   font-weight: ${(props: { bold?: boolean }) => (props.bold ? 700 : "normal")};
   /* border-bottom: 7px solid rgba(255, 255, 255, 1); */
   /* background-color: rgba(255, 255, 0, 0.9); */
@@ -89,13 +89,13 @@ const SpeakerCard = styled.div`
 `;
 
 export const Title = styled.h2`
-  font-size: 1.4em;
+  font-size: 1.27em;
   line-height: 1.4;
-  font-weight: bold;
+  font-weight: normal;
   margin: 0px 0;
   padding: 0;
   flex: 1;
-  color: rgba(255, 255, 255, 0.85);
+  color: rgba(255, 255, 255, 1);
 
   @media screen and (max-width: 1024px) {
     font-size: 1.4em;

--- a/data/talks.tsx
+++ b/data/talks.tsx
@@ -1,5 +1,9 @@
 import { ReactNode } from "react";
+import styled from "styled-components";
 
+const SmallFont = styled.span`
+  font-size: 0.85em;
+`;
 export type Talk = {
   speakerId?: string;
   title?: ReactNode;
@@ -13,51 +17,86 @@ export type Talk = {
 export const talks: { [id: string]: Talk } = {
   "1": {
     speakerId: "1",
-    title: "Keynote",
+    title: "Opening Keynote"
   },
   "2": {
     speakerId: "2",
     title: "Shipping Tiny WebAssembly Builds",
-    abstract: "Code size matters in many places, especially (but not only!) on the Web. This talk will present current best practices in generating small WebAssembly builds when using popular toolchains like LLVM, Emscripten, Rust, Go, and AssemblyScript."
+    abstract:
+      "Code size matters in many places, especially (but not only!) on the Web. This talk will present current best practices in generating small WebAssembly builds when using popular toolchains like LLVM, Emscripten, Rust, Go, and AssemblyScript."
   },
   "3": {
     speakerId: "3",
-    title: "Why the #wasmsummit Website isn't written in Wasm, and what that means for the future of Wasm",
-    abstract: (<><p>WebAssembly is not here to kill JavaScript. In fact, to be successful, it *must not*. But let me back up.</p>
+    title: (
+      <SmallFont>
+        Why the #wasmsummit Website isn't written in Wasm, and what that means
+        for the future of Wasm
+      </SmallFont>
+    ),
+    abstract: (
+      <>
+        <p>
+          WebAssembly is not here to kill JavaScript. In fact, to be successful,
+          it *must not*. But let me back up.
+        </p>
 
-<p>WebAssembly is an exciting new technology that has the ambition to change how and what we program for not only the web, but everywhere. In the case of the web platform, WebAssembly's promise has led many to declare that WebAssembly's entrance means the death of JavaScript. This belief is not only reactionary, but deeply short-sighted, and likely to threaten the successful wide-spread adoption of WebAssembly.</p>
+        <p>
+          WebAssembly is an exciting new technology that has the ambition to
+          change how and what we program for not only the web, but everywhere.
+          In the case of the web platform, WebAssembly's promise has led many to
+          declare that WebAssembly's entrance means the death of JavaScript.
+          This belief is not only reactionary, but deeply short-sighted, and
+          likely to threaten the successful wide-spread adoption of WebAssembly.
+        </p>
 
-<p>In this talk, we'll use the WebAssembly Summit website to discuss the uses and misuses of WebAssembly on the web. We'll explore the historical and material conditions of the web, past and present, to understand *how* and *why* the web changes and what its current trajectory is. With this understanding, we'll explore how WebAssembly can navigate this unique moment and discuss the practical implications of the specification's growth and better tooling as WebAssembly searches for its place in the web platform and beyond.</p></>)
+        <p>
+          In this talk, we'll use the WebAssembly Summit website to discuss the
+          uses and misuses of WebAssembly on the web. We'll explore the
+          historical and material conditions of the web, past and present, to
+          understand *how* and *why* the web changes and what its current
+          trajectory is. With this understanding, we'll explore how WebAssembly
+          can navigate this unique moment and discuss the practical implications
+          of the specification's growth and better tooling as WebAssembly
+          searches for its place in the web platform and beyond.
+        </p>
+      </>
+    )
   },
   "4": {
     speakerId: "4",
     title: "JavaScriptCore's new WebAssembly interpreter",
-    abstract: "In this talk, we will look at JavaScriptCore's newest WebAssembly tier, the Low Level Interpreter (LLInt). With the addition of the interpreter, JavaScriptCore now uses three tiers to execute WebAssembly: LLInt, BBQ and OMG. Because of the new interpreter, WebAssembly programs executing in JavaScriptCore now start up 3x faster. Because of the three-tiered approach, we were able to achieve this while maintaining the same throughput performance."
+    abstract:
+      "In this talk, we will look at JavaScriptCore's newest WebAssembly tier, the Low Level Interpreter (LLInt). With the addition of the interpreter, JavaScriptCore now uses three tiers to execute WebAssembly: LLInt, BBQ and OMG. Because of the new interpreter, WebAssembly programs executing in JavaScriptCore now start up 3x faster. Because of the three-tiered approach, we were able to achieve this while maintaining the same throughput performance."
   },
   "5": {
     speakerId: "5",
     title: "WebAssembly Music",
-    abstract: "Been playing with computer music since the 80s from the tracker era to modern soft synths and DAWs, and even writing some myself. Recently as WebAssembly  came along with excellent performance, and AudioWorklet technology in  providing low latency audio, it's finally possible to use the web for serious music production. As a programmer I like to use a programming language for expressing the music, and also for synthesizing the instruments. I compose my music in Javascript and create my instruments in AssemblyScript which is compiled to WebAssembly. It's all running in the browser. You can write the music in a live coding-environment, and you can play and record the instruments with a midi-keyboard."
+    abstract:
+      "Been playing with computer music since the 80s from the tracker era to modern soft synths and DAWs, and even writing some myself. Recently as WebAssembly  came along with excellent performance, and AudioWorklet technology in  providing low latency audio, it's finally possible to use the web for serious music production. As a programmer I like to use a programming language for expressing the music, and also for synthesizing the instruments. I compose my music in Javascript and create my instruments in AssemblyScript which is compiled to WebAssembly. It's all running in the browser. You can write the music in a live coding-environment, and you can play and record the instruments with a midi-keyboard."
   },
   "6": {
     speakerId: "6",
-    title: "Making it easier to make Things: WebAssembly and the Internet of Things",
-    abstract: "WebAssembly is moving beyond the browser - but is it ready for IoT apps and tiny embedded devices? Yes...ish. In this talk, learn about the state of running Wasm on embedded devices (as low as 512kb of RAM & 64 MHz) and what's left to solve. Also learn where Wasm can today help with IoT protocols and tools."
+    title:
+      "Making it easier to make Things: WebAssembly and the Internet of Things",
+    abstract:
+      "WebAssembly is moving beyond the browser - but is it ready for IoT apps and tiny embedded devices? Yes...ish. In this talk, learn about the state of running Wasm on embedded devices (as low as 512kb of RAM & 64 MHz) and what's left to solve. Also learn where Wasm can today help with IoT protocols and tools."
   },
   "7": {
     speakerId: "7",
     title: "Building a Containerless Future with WebAssembly",
-    abstract: "WebAssembly is the future of distributed computing. Its security, memory isolation, small footprint, and true portability are all advantages on the web, but become truly game-changing when used to build functions and services deployed in the cloud. This session illustrates how to host WebAssembly modules in Rust code, how to build modules in many different languages (including pros and cons of each), and how to securely grant cloud-native capabilities to these modules. Discussed in detail is the current state of the art in WebAssembly and what can be built with it today. Learn what developers can start doing now to build the containerless future where WebAssembly modules are the de-facto unit of immutable deployment in the cloud, at the edge, and even in IoT and embedded devices."
+    abstract:
+      "WebAssembly is the future of distributed computing. Its security, memory isolation, small footprint, and true portability are all advantages on the web, but become truly game-changing when used to build functions and services deployed in the cloud. This session illustrates how to host WebAssembly modules in Rust code, how to build modules in many different languages (including pros and cons of each), and how to securely grant cloud-native capabilities to these modules. Discussed in detail is the current state of the art in WebAssembly and what can be built with it today. Learn what developers can start doing now to build the containerless future where WebAssembly modules are the de-facto unit of immutable deployment in the cloud, at the edge, and even in IoT and embedded devices."
   },
   "8": {
     speakerId: "8",
     title: "WebAssembly as a <video> polyfill",
-    abstract: "An introduction to Wikipedia's ogv.js media compatibility shim, which uses WebAssembly codecs to provide video file format compatibility for VP9 and AV1 video in browsers that don't play them natively. Will explore the division between the JS and Wasm parts of the code base, and how advances in emscripten and LLVM create opportunities and challenges for performance as different browsers implement different levels of the spec (threading, SIMD, etc)."
+    abstract:
+      "An introduction to Wikipedia's ogv.js media compatibility shim, which uses WebAssembly codecs to provide video file format compatibility for VP9 and AV1 video in browsers that don't play them natively. Will explore the division between the JS and Wasm parts of the code base, and how advances in emscripten and LLVM create opportunities and challenges for performance as different browsers implement different levels of the spec (threading, SIMD, etc)."
   },
   "9": {
     speakerId: "9",
-    title: "Keynote",
-  },
+    title: "Closing Keynote"
+  }
 };
 
 "";

--- a/data/talks.tsx
+++ b/data/talks.tsx
@@ -2,7 +2,7 @@ import { ReactNode } from "react";
 import styled from "styled-components";
 
 const SmallFont = styled.span`
-  font-size: 0.85em;
+  font-size: 0.8em;
 `;
 export type Talk = {
   speakerId?: string;

--- a/data/talks.tsx
+++ b/data/talks.tsx
@@ -27,12 +27,8 @@ export const talks: { [id: string]: Talk } = {
   },
   "3": {
     speakerId: "3",
-    title: (
-      <SmallFont>
-        Why the #wasmsummit Website isn't written in Wasm, and what that means
-        for the future of Wasm
-      </SmallFont>
-    ),
+    title:
+      "Why the #wasmsummit Website isn't written in Wasm, and what that means for the future of Wasm",
     abstract: (
       <>
         <p>

--- a/pages/speakers/[id].tsx
+++ b/pages/speakers/[id].tsx
@@ -54,20 +54,22 @@ const SpeakerPage: FC = () => {
                     {time.start && time.end && `${time.start} - ${time.end}`}
                   </p>
                   <Title>{talk.title}</Title>
-                  {speaker.website && (
-                    <Links>
-                      <Icon>
-                        <LinkIcon size={32}></LinkIcon>
-                      </Icon>
-                    </Links>
-                  )}
                 </SpeakerSummary>
               </SpeakerCard>
             </a>
           )}
         </SpeakerBox>
         <Section>
-          <Headline>{speaker.name}</Headline>
+          <Headline>
+            {speaker.name}{" "}
+            {speaker.website && (
+              <a href={speaker.website} target="_blank">
+                <Icon>
+                  <LinkIcon size={25}></LinkIcon>
+                </Icon>
+              </a>
+            )}
+          </Headline>
           <SpeakerNameHeadline>{talk.title}</SpeakerNameHeadline>
           {talk.time && talk.time.start && talk.time.end && (
             <SectionHeading>
@@ -76,34 +78,26 @@ const SpeakerPage: FC = () => {
                 talk.time.end}`}
             </SectionHeading>
           )}
+
           <SectionContent>{talk.abstract}</SectionContent>
           <SpeakerBottomBox>
             {speaker.name && (
-              <a href={speaker.website} target="_blank">
-                <SpeakerCard>
-                  <img
-                    src={speaker.picture}
-                    alt={`picture of ${speaker.name}`}
-                  ></img>
-                  <SpeakerName>
-                    <strong>{speaker.name}</strong>{" "}
-                    {speaker.company && <Company>{speaker.company}</Company>}
-                  </SpeakerName>
-                  <SpeakerSummary>
-                    <p>
-                      {time.start && time.end && `${time.start} - ${time.end}`}
-                    </p>
-                    <Title>{talk.title}</Title>
-                    {speaker.website && (
-                      <Links>
-                        <Icon>
-                          <LinkIcon size={32}></LinkIcon>
-                        </Icon>
-                      </Links>
-                    )}
-                  </SpeakerSummary>
-                </SpeakerCard>
-              </a>
+              <SpeakerCard>
+                <img
+                  src={speaker.picture}
+                  alt={`picture of ${speaker.name}`}
+                ></img>
+                <SpeakerName>
+                  <strong>{speaker.name}</strong>{" "}
+                  {speaker.company && <Company>{speaker.company}</Company>}
+                </SpeakerName>
+                <SpeakerSummary>
+                  <p>
+                    {time.start && time.end && `${time.start} - ${time.end}`}
+                  </p>
+                  <Title>{talk.title}</Title>
+                </SpeakerSummary>
+              </SpeakerCard>
             )}
           </SpeakerBottomBox>
         </Section>
@@ -118,12 +112,18 @@ const Links = styled.div`
   display: flex;
   flex-direction: row;
   align-items: center;
-  justify-content: flex-end;
+  justify-content: flex-start;
+  margin-left: 5px;
 `;
 
-export const Icon = styled.div`
-  padding: 0 10px;
-  color: rgba(255, 255, 255, 0.8);
+export const Icon = styled.span`
+  padding: 5px 10px;
+  color: rgba(255, 255, 255, 0.7);
+  transition: 150ms;
+
+  &:hover {
+    color: white;
+  }
 `;
 
 const Time = styled.div``;
@@ -143,7 +143,7 @@ const Background = styled.div`
 const SpeakerBox = styled.div`
   display: flex;
   flex-direction: column;
-  margin: 4vh 3vw 0vh 3vw;
+  margin: 5vh 3vw 0vh 3vw;
   align-items: center;
 
   @media screen and (max-width: 1000px) {
@@ -154,7 +154,7 @@ const SpeakerBox = styled.div`
 const SpeakerBottomBox = styled.div`
   display: flex;
   flex-direction: column;
-  margin: 25px 15px;
+  margin: 0 15px;
   align-items: flex-start;
 
   @media screen and (min-width: 999px) {
@@ -235,7 +235,7 @@ const SectionSubHeading = styled.p`
 
 const SectionContent = styled.div`
   font-size: 1.3em;
-  margin: 5vh 15px 0vh 15px;
+  margin: 5vh 15px 3vh 15px;
   /*   padding: 0 15px 50px 25px;
  */
   line-height: 1.8;
@@ -286,7 +286,7 @@ export const SpeakerSummary = styled.div`
   justify-content: center;
   padding: 15px 30px 30px 30px;
   background: hsl(239, 50%, 25%);
-  height: 150px;
+  height: 130px;
   line-height: 1.8;
   font-size: 1em;
 
@@ -301,7 +301,7 @@ export const SpeakerSummary = styled.div`
 
   @media (max-width: 1280px) {
     padding: 15px 25px;
-    height: 160px;
+    height: 130px;
     line-height: 1.6;
   }
   color: rgba(255, 255, 255, 0.8);

--- a/pages/speakers/[id].tsx
+++ b/pages/speakers/[id].tsx
@@ -6,6 +6,7 @@ import {
   navbarBlue,
   SpeakerCard,
   SpeakerName,
+  SpeakerSummary,
   Title,
   Company
 } from "../../components";
@@ -51,6 +52,10 @@ const SpeakerPage: FC = () => {
                     {speaker.company && <Company>{speaker.company}</Company>}
                   </SpeakerName>
                   <SpeakerSummary>
+                    <p>
+                      {time.start && time.end && `${time.start} - ${time.end}`}
+                    </p>
+                    <Title>{talk.title}</Title>
                     {speaker.website && (
                       <>
                         <Links>
@@ -66,15 +71,13 @@ const SpeakerPage: FC = () => {
             )}
           </SpeakerBox>
           <Section>
-            {speaker.name && <SectionHeading>{talk.title}</SectionHeading>}
-            <SectionSubHeading>
-              {talk.time &&
-                talk.time.start &&
-                talk.time.end &&
-                `${talk.time && talk.time.start} - ${talk.time &&
+            {talk.time && talk.time.start && talk.time.end && (
+              <SectionHeading>
+                {" "}
+                {`${talk.time && talk.time.start} - ${talk.time &&
                   talk.time.end}`}
-            </SectionSubHeading>
-
+              </SectionHeading>
+            )}
             <SectionContent>{talk.abstract}</SectionContent>
           </Section>
         </Columns>
@@ -113,11 +116,13 @@ const Background = styled.div`
 
 const SpeakerBox = styled.div`
   display: flex;
+  flex: 1;
   flex-direction: column;
   margin-top: 0vh;
   margin-bottom: 2vh;
   margin-right: 0;
   padding-top: 0;
+  align-items: flex-end;
 
   @media screen and (max-width: 450px) {
     /* display: none; */
@@ -153,7 +158,7 @@ export const Headline = styled.h2`
 const Content = styled.div`
   display: flex;
   flex-direction: row;
-  padding: 3vh 3vw;
+  padding: 1vh 3vw;
   color: white;
   min-height: calc(100vh - 65px);
   align-items: center;
@@ -175,8 +180,7 @@ const Columns = styled.div`
 
 const Section = styled.div`
   break-inside: avoid;
-  flex: 1;
-  margin: 1vh 3vw 0vh 3vw;
+  flex: 2;
   max-width: 1024px;
 `;
 
@@ -202,19 +206,20 @@ const SectionSubHeading = styled.p`
 `;
 
 const SectionContent = styled.div`
-  font-size: 1.2em;
-  margin: 0 0px 0 0;
-  padding: 0 15px 50px 25px;
+  font-size: 1.3em;
+  margin: 5vh 3vw 0vh 3vw;
+  /*   padding: 0 15px 50px 25px;
+ */
   line-height: 1.8;
   color: rgba(255, 255, 255, 0.9);
   text-shadow: 1px 4px 10px rgba(0, 0, 0, 0.25);
   font-weight: ${(props: { bold?: boolean }) => (props.bold ? 700 : "normal")};
 `;
 
-export const SpeakerSummary = styled.div`
+/* export const SpeakerSummary = styled.div`
   padding: 15px 30px 30px 30px;
   background: hsl(239, 50%, 25%);
-  height: 40px;
+  height: 130px;
   line-height: 1.8;
   font-size: 0.78em;
   display: flex;
@@ -232,8 +237,8 @@ export const SpeakerSummary = styled.div`
 
   @media (max-width: 1280px) {
     padding: 15px 25px;
-    height: 50px;
+    height: 140px;
     line-height: 1.6;
   }
   color: rgba(255, 255, 255, 0.8);
-`;
+`; */

--- a/pages/speakers/[id].tsx
+++ b/pages/speakers/[id].tsx
@@ -57,13 +57,11 @@ const SpeakerPage: FC = () => {
                     </p>
                     <Title>{talk.title}</Title>
                     {speaker.website && (
-                      <>
-                        <Links>
-                          <Icon>
-                            <LinkIcon size={32}></LinkIcon>
-                          </Icon>
-                        </Links>
-                      </>
+                      <Links>
+                        <Icon>
+                          <LinkIcon size={32}></LinkIcon>
+                        </Icon>
+                      </Links>
                     )}
                   </SpeakerSummary>
                 </SpeakerCard>

--- a/pages/speakers/[id].tsx
+++ b/pages/speakers/[id].tsx
@@ -6,7 +6,6 @@ import {
   navbarBlue,
   SpeakerCard,
   SpeakerName,
-  SpeakerSummary,
   Title,
   Company
 } from "../../components";
@@ -38,47 +37,47 @@ const SpeakerPage: FC = () => {
       <NavBar title={title} backgroundColor={navbarBlue} bottom />
       <Content>
         {/* <PageTitle>{title}</PageTitle> */}
-        <Columns>
-          <SpeakerBox>
-            {speaker.name && (
-              <a href={speaker.website} target="_blank">
-                <SpeakerCard>
-                  <img
-                    src={speaker.picture}
-                    alt={`picture of ${speaker.name}`}
-                  ></img>
-                  <SpeakerName>
-                    <strong>{speaker.name}</strong>{" "}
-                    {speaker.company && <Company>{speaker.company}</Company>}
-                  </SpeakerName>
-                  <SpeakerSummary>
-                    <p>
-                      {time.start && time.end && `${time.start} - ${time.end}`}
-                    </p>
-                    <Title>{talk.title}</Title>
-                    {speaker.website && (
-                      <Links>
-                        <Icon>
-                          <LinkIcon size={32}></LinkIcon>
-                        </Icon>
-                      </Links>
-                    )}
-                  </SpeakerSummary>
-                </SpeakerCard>
-              </a>
-            )}
-          </SpeakerBox>
-          <Section>
-            {talk.time && talk.time.start && talk.time.end && (
-              <SectionHeading>
-                {" "}
-                {`${talk.time && talk.time.start} - ${talk.time &&
-                  talk.time.end}`}
-              </SectionHeading>
-            )}
-            <SectionContent>{talk.abstract}</SectionContent>
-          </Section>
-        </Columns>
+        <SpeakerBox>
+          {speaker.name && (
+            <a href={speaker.website} target="_blank">
+              <SpeakerCard>
+                <img
+                  src={speaker.picture}
+                  alt={`picture of ${speaker.name}`}
+                ></img>
+                <SpeakerName>
+                  <strong>{speaker.name}</strong>{" "}
+                  {speaker.company && <Company>{speaker.company}</Company>}
+                </SpeakerName>
+                <SpeakerSummary>
+                  <p>
+                    {time.start && time.end && `${time.start} - ${time.end}`}
+                  </p>
+                  <Title>{talk.title}</Title>
+                  {speaker.website && (
+                    <Links>
+                      <Icon>
+                        <LinkIcon size={32}></LinkIcon>
+                      </Icon>
+                    </Links>
+                  )}
+                </SpeakerSummary>
+              </SpeakerCard>
+            </a>
+          )}
+        </SpeakerBox>
+        <Section>
+          <Headline>{speaker.name}</Headline>
+          <SpeakerNameHeadline>{talk.title}</SpeakerNameHeadline>
+          {talk.time && talk.time.start && talk.time.end && (
+            <SectionHeading>
+              {" "}
+              {`${talk.time && talk.time.start} - ${talk.time &&
+                talk.time.end}`}
+            </SectionHeading>
+          )}
+          <SectionContent>{talk.abstract}</SectionContent>
+        </Section>
       </Content>
     </>
   );
@@ -114,17 +113,12 @@ const Background = styled.div`
 
 const SpeakerBox = styled.div`
   display: flex;
-  flex: 1;
   flex-direction: column;
-  margin-top: 0vh;
-  margin-bottom: 2vh;
-  margin-right: 0;
-  padding-top: 0;
-  align-items: flex-end;
+  margin: 4vh 3vw 0vh 3vw;
+  align-items: center;
 
   @media screen and (max-width: 450px) {
-    /* display: none; */
-    margin-top: 3vh;
+    display: none;
   }
 `;
 
@@ -144,6 +138,8 @@ export const PageTitle = styled.h1`
 
 export const Headline = styled.h2`
   font-size: 2em;
+  margin: 0;
+
   margin-top: 3vh;
   margin-bottom: 0vh;
   padding: 0 15px;
@@ -156,27 +152,20 @@ export const Headline = styled.h2`
 const Content = styled.div`
   display: flex;
   flex-direction: row;
+  flex-wrap: wrap;
   padding: 1vh 3vw;
   color: white;
   min-height: calc(100vh - 65px);
-  align-items: center;
-  justify-content: center;
-`;
-
-const Columns = styled.div`
-  background-color: ${(props: { primary?: boolean }) =>
-    props.primary ? "#fff" : "transparent"};
-  box-shadow: ${(props: { primary?: boolean }) =>
-    props.primary ? "0px 5px 30px rgba(0,0,0,0.01)" : "0px"};
-  color: #fff;
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-  justify-content: center;
   align-items: flex-start;
+  justify-content: center;
+
+  @media screen and (orientation: portrait) {
+    flex-direction: row;
+  }
 `;
 
 const Section = styled.div`
+  margin-top: 3vh;
   break-inside: avoid;
   flex: 2;
   max-width: 1024px;
@@ -205,7 +194,7 @@ const SectionSubHeading = styled.p`
 
 const SectionContent = styled.div`
   font-size: 1.3em;
-  margin: 5vh 3vw 0vh 3vw;
+  margin: 5vh 15px 0vh 15px;
   /*   padding: 0 15px 50px 25px;
  */
   line-height: 1.8;
@@ -240,3 +229,39 @@ const SectionContent = styled.div`
   }
   color: rgba(255, 255, 255, 0.8);
 `; */
+
+const SpeakerNameHeadline = styled.h2`
+  font-size: 1.5em;
+  padding-bottom: 15px;
+  padding-left: 15px;
+  font-weight: 700;
+  border-bottom: 3px solid rgba(255, 255, 255, 0.4);
+  text-shadow: 2px 4px 5px hsla(237, 80%, 35%, 0.3);
+`;
+
+export const SpeakerSummary = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  padding: 15px 30px 30px 30px;
+  background: hsl(239, 50%, 25%);
+  height: 150px;
+  line-height: 1.8;
+  font-size: 1em;
+
+  p {
+    color: rgba(255, 255, 255, 0.5);
+    margin: 0;
+    margin-bottom: 5px;
+    font-weight: normal;
+    font-size: 1.8em;
+    padding: 0;
+  }
+
+  @media (max-width: 1280px) {
+    padding: 15px 25px;
+    height: 160px;
+    line-height: 1.6;
+  }
+  color: rgba(255, 255, 255, 0.8);
+`;

--- a/pages/speakers/[id].tsx
+++ b/pages/speakers/[id].tsx
@@ -77,6 +77,35 @@ const SpeakerPage: FC = () => {
             </SectionHeading>
           )}
           <SectionContent>{talk.abstract}</SectionContent>
+          <SpeakerBottomBox>
+            {speaker.name && (
+              <a href={speaker.website} target="_blank">
+                <SpeakerCard>
+                  <img
+                    src={speaker.picture}
+                    alt={`picture of ${speaker.name}`}
+                  ></img>
+                  <SpeakerName>
+                    <strong>{speaker.name}</strong>{" "}
+                    {speaker.company && <Company>{speaker.company}</Company>}
+                  </SpeakerName>
+                  <SpeakerSummary>
+                    <p>
+                      {time.start && time.end && `${time.start} - ${time.end}`}
+                    </p>
+                    <Title>{talk.title}</Title>
+                    {speaker.website && (
+                      <Links>
+                        <Icon>
+                          <LinkIcon size={32}></LinkIcon>
+                        </Icon>
+                      </Links>
+                    )}
+                  </SpeakerSummary>
+                </SpeakerCard>
+              </a>
+            )}
+          </SpeakerBottomBox>
         </Section>
       </Content>
     </>
@@ -117,7 +146,18 @@ const SpeakerBox = styled.div`
   margin: 4vh 3vw 0vh 3vw;
   align-items: center;
 
-  @media screen and (max-width: 450px) {
+  @media screen and (max-width: 1000px) {
+    display: none;
+  }
+`;
+
+const SpeakerBottomBox = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin: 25px 15px;
+  align-items: flex-start;
+
+  @media screen and (min-width: 999px) {
     display: none;
   }
 `;
@@ -169,6 +209,7 @@ const Section = styled.div`
   break-inside: avoid;
   flex: 2;
   max-width: 1024px;
+  min-width: 350px;
 `;
 
 const SectionHeading = styled.h2`

--- a/pages/speakers/[id].tsx
+++ b/pages/speakers/[id].tsx
@@ -50,10 +50,10 @@ const SpeakerPage: FC = () => {
                   {speaker.company && <Company>{speaker.company}</Company>}
                 </SpeakerName>
                 <SpeakerSummary>
-                  <p>
+                  {/* <p>
                     {time.start && time.end && `${time.start} - ${time.end}`}
                   </p>
-                  <Title>{talk.title}</Title>
+                  <Title>{talk.title}</Title> */}
                 </SpeakerSummary>
               </SpeakerCard>
             </a>
@@ -92,10 +92,10 @@ const SpeakerPage: FC = () => {
                   {speaker.company && <Company>{speaker.company}</Company>}
                 </SpeakerName>
                 <SpeakerSummary>
-                  <p>
+                  {/* <p>
                     {time.start && time.end && `${time.start} - ${time.end}`}
                   </p>
-                  <Title>{talk.title}</Title>
+                  <Title>{talk.title}</Title> */}
                 </SpeakerSummary>
               </SpeakerCard>
             )}


### PR DESCRIPTION
- I've fixed the collapsing layout of the speaker page when there is no abstract to deal with missing content
- rounded off a few rough edges, in particular on smaller tablets in portrait mode the layout switched to column mode more quickly #62. 
- Also, on mobile the layout was confusing, if you click on the card you see the card again with no headline, therefore I moved the card down and added a headline. 
- aspect ratio of the speaker card now matches the speakers page
- layout starts on the top of the screen instead of in the middle to lessen the orphaned look when there is little content

here how it was before

<img width="1464" alt="Bildschirmfoto 2020-01-14 um 13 12 15" src="https://user-images.githubusercontent.com/347722/72345343-c50a3000-36d3-11ea-8141-ef3907fd50f9.png">

and after:
<img width="1440" alt="Bildschirmfoto 2020-01-14 um 13 13 02" src="https://user-images.githubusercontent.com/347722/72345357-cb001100-36d3-11ea-8867-f549e59ad875.png">
