### PR TITLE
Fix broken speaker links

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,4 @@
 module.exports = {
-  exportTrailingSlash: true,
   exportPathMap: async function() {
     const paths = {
       "/": { page: "/" },


### PR DESCRIPTION
if you copy paste the links from the speaker page they're broken without adding an additional trailing slash. this fixes it