### PR TITLE
Minor refinement to speakers overview page

### DIFF
--- a/components/SpeakerCard.tsx
+++ b/components/SpeakerCard.tsx
@@ -7,14 +7,14 @@ export const SpeakerSummary = styled.div`
   background: hsl(239, 50%, 25%);
   height: 140px;
   line-height: 1.8;
-  font-size: 0.78em;
+  font-size: 1em;
 
   p {
     color: rgba(255, 255, 255, 0.5);
     margin: 0;
     margin-bottom: 5px;
     font-weight: normal;
-    font-size: 1.4em;
+    font-size: 1.8em;
     padding: 0;
   }
 
@@ -38,7 +38,7 @@ export const SpeakerName = styled.div`
   color: white;
   margin: 0;
   margin: 0;
-  padding: 8px 15px;
+  padding: 10px 15px;
   font-weight: ${(props: { bold?: boolean }) => (props.bold ? 700 : "normal")};
   /* border-bottom: 7px solid rgba(255, 255, 255, 1); */
   /* background-color: rgba(255, 255, 0, 0.9); */
@@ -86,15 +86,23 @@ const SpeakerCard = styled.div`
 `;
 
 export const Title = styled.h2`
-  font-size: 1.6em;
+  font-size: 1.5em;
   line-height: 1.4;
-  font-weight: bold;
+  font-weight: normal;
   margin: 0px 0;
   padding: 0;
   color: rgba(255, 255, 255, 0.85);
 
-  @media screen and (max-width: 1024px) {
+  @media screen and (max-width: 1280px) {
+    font-size: 1.27em;
+  }
+
+  @media screen and (max-width: 663px) {
     font-size: 1.5em;
+  }
+
+  @media screen and (max-width: 450px) {
+    font-size: 1.27em;
   }
 `;
 

--- a/data/talks.tsx
+++ b/data/talks.tsx
@@ -13,51 +13,82 @@ export type Talk = {
 export const talks: { [id: string]: Talk } = {
   "1": {
     speakerId: "1",
-    title: "Keynote",
+    title: "Opening Keynote"
   },
   "2": {
     speakerId: "2",
     title: "Shipping Tiny WebAssembly Builds",
-    abstract: "Code size matters in many places, especially (but not only!) on the Web. This talk will present current best practices in generating small WebAssembly builds when using popular toolchains like LLVM, Emscripten, Rust, Go, and AssemblyScript."
+    abstract:
+      "Code size matters in many places, especially (but not only!) on the Web. This talk will present current best practices in generating small WebAssembly builds when using popular toolchains like LLVM, Emscripten, Rust, Go, and AssemblyScript."
   },
   "3": {
     speakerId: "3",
-    title: "Why the #wasmsummit Website isn't written in Wasm, and what that means for the future of Wasm",
-    abstract: (<><p>WebAssembly is not here to kill JavaScript. In fact, to be successful, it *must not*. But let me back up.</p>
+    title:
+      "Why the #wasmsummit Website isn't written in Wasm, and what that means for the future of Wasm",
+    abstract: (
+      <>
+        <p>
+          WebAssembly is not here to kill JavaScript. In fact, to be successful,
+          it *must not*. But let me back up.
+        </p>
 
-<p>WebAssembly is an exciting new technology that has the ambition to change how and what we program for not only the web, but everywhere. In the case of the web platform, WebAssembly's promise has led many to declare that WebAssembly's entrance means the death of JavaScript. This belief is not only reactionary, but deeply short-sighted, and likely to threaten the successful wide-spread adoption of WebAssembly.</p>
+        <p>
+          WebAssembly is an exciting new technology that has the ambition to
+          change how and what we program for not only the web, but everywhere.
+          In the case of the web platform, WebAssembly's promise has led many to
+          declare that WebAssembly's entrance means the death of JavaScript.
+          This belief is not only reactionary, but deeply short-sighted, and
+          likely to threaten the successful wide-spread adoption of WebAssembly.
+        </p>
 
-<p>In this talk, we'll use the WebAssembly Summit website to discuss the uses and misuses of WebAssembly on the web. We'll explore the historical and material conditions of the web, past and present, to understand *how* and *why* the web changes and what its current trajectory is. With this understanding, we'll explore how WebAssembly can navigate this unique moment and discuss the practical implications of the specification's growth and better tooling as WebAssembly searches for its place in the web platform and beyond.</p></>)
+        <p>
+          In this talk, we'll use the WebAssembly Summit website to discuss the
+          uses and misuses of WebAssembly on the web. We'll explore the
+          historical and material conditions of the web, past and present, to
+          understand *how* and *why* the web changes and what its current
+          trajectory is. With this understanding, we'll explore how WebAssembly
+          can navigate this unique moment and discuss the practical implications
+          of the specification's growth and better tooling as WebAssembly
+          searches for its place in the web platform and beyond.
+        </p>
+      </>
+    )
   },
   "4": {
     speakerId: "4",
     title: "JavaScriptCore's new WebAssembly interpreter",
-    abstract: "In this talk, we will look at JavaScriptCore's newest WebAssembly tier, the Low Level Interpreter (LLInt). With the addition of the interpreter, JavaScriptCore now uses three tiers to execute WebAssembly: LLInt, BBQ and OMG. Because of the new interpreter, WebAssembly programs executing in JavaScriptCore now start up 3x faster. Because of the three-tiered approach, we were able to achieve this while maintaining the same throughput performance."
+    abstract:
+      "In this talk, we will look at JavaScriptCore's newest WebAssembly tier, the Low Level Interpreter (LLInt). With the addition of the interpreter, JavaScriptCore now uses three tiers to execute WebAssembly: LLInt, BBQ and OMG. Because of the new interpreter, WebAssembly programs executing in JavaScriptCore now start up 3x faster. Because of the three-tiered approach, we were able to achieve this while maintaining the same throughput performance."
   },
   "5": {
     speakerId: "5",
     title: "WebAssembly Music",
-    abstract: "Been playing with computer music since the 80s from the tracker era to modern soft synths and DAWs, and even writing some myself. Recently as WebAssembly  came along with excellent performance, and AudioWorklet technology in  providing low latency audio, it's finally possible to use the web for serious music production. As a programmer I like to use a programming language for expressing the music, and also for synthesizing the instruments. I compose my music in Javascript and create my instruments in AssemblyScript which is compiled to WebAssembly. It's all running in the browser. You can write the music in a live coding-environment, and you can play and record the instruments with a midi-keyboard."
+    abstract:
+      "Been playing with computer music since the 80s from the tracker era to modern soft synths and DAWs, and even writing some myself. Recently as WebAssembly  came along with excellent performance, and AudioWorklet technology in  providing low latency audio, it's finally possible to use the web for serious music production. As a programmer I like to use a programming language for expressing the music, and also for synthesizing the instruments. I compose my music in Javascript and create my instruments in AssemblyScript which is compiled to WebAssembly. It's all running in the browser. You can write the music in a live coding-environment, and you can play and record the instruments with a midi-keyboard."
   },
   "6": {
     speakerId: "6",
-    title: "Making it easier to make Things: WebAssembly and the Internet of Things",
-    abstract: "WebAssembly is moving beyond the browser - but is it ready for IoT apps and tiny embedded devices? Yes...ish. In this talk, learn about the state of running Wasm on embedded devices (as low as 512kb of RAM & 64 MHz) and what's left to solve. Also learn where Wasm can today help with IoT protocols and tools."
+    title:
+      "Making it easier to make Things: WebAssembly and the Internet of Things",
+    abstract:
+      "WebAssembly is moving beyond the browser - but is it ready for IoT apps and tiny embedded devices? Yes...ish. In this talk, learn about the state of running Wasm on embedded devices (as low as 512kb of RAM & 64 MHz) and what's left to solve. Also learn where Wasm can today help with IoT protocols and tools."
   },
   "7": {
     speakerId: "7",
     title: "Building a Containerless Future with WebAssembly",
-    abstract: "WebAssembly is the future of distributed computing. Its security, memory isolation, small footprint, and true portability are all advantages on the web, but become truly game-changing when used to build functions and services deployed in the cloud. This session illustrates how to host WebAssembly modules in Rust code, how to build modules in many different languages (including pros and cons of each), and how to securely grant cloud-native capabilities to these modules. Discussed in detail is the current state of the art in WebAssembly and what can be built with it today. Learn what developers can start doing now to build the containerless future where WebAssembly modules are the de-facto unit of immutable deployment in the cloud, at the edge, and even in IoT and embedded devices."
+    abstract:
+      "WebAssembly is the future of distributed computing. Its security, memory isolation, small footprint, and true portability are all advantages on the web, but become truly game-changing when used to build functions and services deployed in the cloud. This session illustrates how to host WebAssembly modules in Rust code, how to build modules in many different languages (including pros and cons of each), and how to securely grant cloud-native capabilities to these modules. Discussed in detail is the current state of the art in WebAssembly and what can be built with it today. Learn what developers can start doing now to build the containerless future where WebAssembly modules are the de-facto unit of immutable deployment in the cloud, at the edge, and even in IoT and embedded devices."
   },
   "8": {
     speakerId: "8",
     title: "WebAssembly as a <video> polyfill",
-    abstract: "An introduction to Wikipedia's ogv.js media compatibility shim, which uses WebAssembly codecs to provide video file format compatibility for VP9 and AV1 video in browsers that don't play them natively. Will explore the division between the JS and Wasm parts of the code base, and how advances in emscripten and LLVM create opportunities and challenges for performance as different browsers implement different levels of the spec (threading, SIMD, etc)."
+    abstract:
+      "An introduction to Wikipedia's ogv.js media compatibility shim, which uses WebAssembly codecs to provide video file format compatibility for VP9 and AV1 video in browsers that don't play them natively. Will explore the division between the JS and Wasm parts of the code base, and how advances in emscripten and LLVM create opportunities and challenges for performance as different browsers implement different levels of the spec (threading, SIMD, etc)."
   },
   "9": {
     speakerId: "9",
-    title: "Keynote",
-  },
+    title: "Closing Keynote"
+  }
 };
 
 "";


### PR DESCRIPTION
This PR addresses the speakers overview page #37 only, not the card on the speaker detail page. It improves a nuance on visual grouping and readability .

Changes:
-  with slightly larger talk title font size and weight change
- improved adaptation of title font size to card sizes on different screen width breakpoints
- talk title description distinguishes "Opening Keynote" and "Closing keynote" (+ code auto formatting)

# Screenshots

## Desktop

### Now
![Bildschirmfoto 2020-01-18 um 17 19 02](https://user-images.githubusercontent.com/347722/72667029-e17dd380-3a17-11ea-9d35-e99d2fb7acf5.png)

#### Before
![Bildschirmfoto 2020-01-18 um 17 27 46](https://user-images.githubusercontent.com/347722/72667031-e5115a80-3a17-11ea-84ae-86bb865ab540.png)

## Mobile

### Now

<img width="307" alt="Bildschirmfoto 2020-01-18 um 17 39 12" src="https://user-images.githubusercontent.com/347722/72667209-a8466300-3a19-11ea-8845-53aaea12cfe8.png">

### Before

<img width="307" alt="Bildschirmfoto 2020-01-18 um 17 39 26" src="https://user-images.githubusercontent.com/347722/72667212-ac728080-3a19-11ea-9bc1-796e0a8c0187.png">
