### PR TITLE
fix for missing schedule route

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -8,7 +8,8 @@ module.exports = withBundleAnalyzer({
     const paths = {
       "/": { page: "/" },
       "/about": { page: "/about" },
-      "/speakers": { page: "/speakers" }
+      "/speakers": { page: "/speakers" },
+      "/schedule": { page: "/schedule" }
     };
 
     [1, 2, 3, 4, 5, 6, 7, 8, 9].forEach(id => {


### PR DESCRIPTION
After we set up the dynamic route for the individual speakerpages `/speakers/1`, all routes need to be exported explicitly. I've added the missing `/schedule` route.