### PR TITLE
Finalized Schedule Page

### DIFF
--- a/data/schedule.tsx
+++ b/data/schedule.tsx
@@ -1,0 +1,87 @@
+export type ScheduleDataItem = {
+  time: string,
+  title: string,
+  description?: string
+  link?: string 
+}
+
+export const schedule: ScheduleDataItem[] = [
+  {
+    time: "8:00am",
+    title: "Breakfast"
+  },
+  {
+    time: "9:00am",
+    title: "Introductions"
+  },
+  {
+    time: "9:15am",
+    title: "Lin Clark",
+    description: "Opening Keynote",
+    link: "/speakers/1/"
+  },
+  {
+    time: "9:55am",
+    title: "Alon Zakai",
+    description: "Shipping Tiny WebAssembly Builds",
+    link: "/speakers/2/"
+  },
+  {
+    time: "10:30am",
+    title: "Morning Coffee Break"
+  },
+  {
+    time: "11:15am",
+    title: "Ashley Williams",
+    description: "Why the #wasmsummit Website isn't written in Wasm, and what that means for the future of Wasm",
+    link: "/speakers/3/"
+  },
+  {
+    time: "12:05pm",
+    title: "Tadeu Zagallo",
+    description: "JavaScriptCore's new WebAssembly interpreter",
+    link: "/speakers/4/"
+  },
+  {
+    time: "12:40pm",
+    title: "Lunch"
+  },
+  {
+    time: "2:05pm",
+    title: "Peter Salomonsen",
+    description: "WebAssembly Music",
+    link: "/speakers/5/"
+  },
+  {
+    time: "2:50pm",
+    title: "Jonathan Beri",
+    description: "Making it easier to make Things: WebAssembly and the Internet of Things",
+    link: "/speakers/6/"
+  },
+  {
+    time: "3:25pm",
+    title: "Afternoon Coffee Break"
+  },
+  {
+    time: "4:10pm",
+    title: "Kevin Hoffman",
+    description: "Building a Containerless Future with WebAssembly",
+    link: "/speakers/7/"
+  },
+  {
+    time: "4:45pm",
+    title: "Brion Vibber",
+    description: "WebAssembly as a <video> polyfill",
+    link: "/speakers/8/"
+  },
+  {
+    time: "5:35pm",
+    title: "Ben Smith",
+    description: "Closing Keynote",
+    link: "/speakers/9/"
+  },
+  {
+    time: "6:15pm",
+    title: "Conference End / Evening Social Hour",
+  }
+];

--- a/pages/schedule.tsx
+++ b/pages/schedule.tsx
@@ -2,38 +2,9 @@ import { FC, ReactNode } from "react";
 import styled from "styled-components";
 import { NavBar, navbarBlue } from "../components";
 
+import { schedule } from '../data/schedule';
+
 const title = "Schedule";
-
-type mockScheduleItem = {
-  time: string,
-  title: string,
-  description?: string
-  link?: string
-}
-
-const scheduleItems: mockScheduleItem[] = [
-  {
-    time: "8:00am",
-    title: "Breakfast"
-  },
-  {
-    time: "9:15am",
-    title: "Introductions"
-  },
-  {
-    time: "9:30am",
-    title: "Lin Clark",
-    description: "Opening Keynote",
-    link: "/speakers/1/"
-  },
-  {
-    time: "10:15am",
-    title: "Alon Zakai",
-    description: "Shipping Tiny WebAssembly Builds",
-    link: "/speakers/2/"
-  }
-
-];
 
 const SchedulePage: FC = () => (
   <>
@@ -42,7 +13,7 @@ const SchedulePage: FC = () => (
   <Container>
     <Headline>{title}</Headline>
     <Schedule>
-      {scheduleItems.map((item, index) => {
+      {schedule.map((item, index) => {
 
         let title = (
           <ScheduleItemTitle>{item.title}</ScheduleItemTitle>
@@ -71,9 +42,10 @@ const SchedulePage: FC = () => (
 
         let itemJsx = (
           <ScheduleItem key={index}>
-            <ScheduleItemTime>{item.time}</ScheduleItemTime>
+            <ScheduleItemTimeDesktop>{item.time}</ScheduleItemTimeDesktop>
             <ScheduleItemCircle />
             <ScheduleItemContent>
+              <ScheduleItemTimeMobile>{item.time}</ScheduleItemTimeMobile>
               {itemContent}
             </ScheduleItemContent>
           </ScheduleItem>
@@ -133,16 +105,29 @@ export const ScheduleItem = styled.li`
   margin-bottom: 10px;
 `;
 
-export const ScheduleItemTime = styled.p`
+export const ScheduleItemTimeDesktop = styled.p`
   font-size: 1em;
   color: #FFFFFF;
   margin: -1px calc(2vw + 5px) 0 0;
   width: 60px;
   @media screen and (max-width: 500px) {
-    font-size: 0.75em;
-    line-height: 1.7;
-    /* margin: 15px 0; */
-    transform-origin: center center;
+    display: none;
+  }
+`;
+
+export const ScheduleItemTimeMobile = styled.p`
+  font-size: 1em;
+  font-weight: 700;
+  color: #FFFFFF;
+  width: 60px;
+  line-height: 1.7;
+  padding-left: 5px;
+  margin-top: -1.3em;
+  margin-bottom: 1em;
+
+  display: none;
+  @media screen and (max-width: 500px) {
+    display: block;
   }
 `;
 
@@ -185,6 +170,7 @@ export const ScheduleItemDescription = styled.p`
 
   @media screen and (max-width: 500px) {
     font-size: 1.4em;
+    font-weight: normal;
   }
 `;
 


### PR DESCRIPTION
This implements the following:

* Adds the current official Schedule page data.
* Fixes up the mobile design to accommodate long titles.
* Adds the Schdule Nav Item

# Screenshots

**Note:** Some screenshots will not have the schedule in the nav, because I decided to include it after I took most of the screenshots :joy: 

## Desktop

![Screenshot from 2020-01-24 23-15-42](https://user-images.githubusercontent.com/1448289/73117790-c3c0da80-3eff-11ea-9f26-e3365f4b26ce.png)
![Screenshot from 2020-01-24 23-12-55](https://user-images.githubusercontent.com/1448289/73117791-c4597100-3eff-11ea-8e52-e20a978f23c7.png)
![Screenshot from 2020-01-24 23-12-53](https://user-images.githubusercontent.com/1448289/73117792-c4597100-3eff-11ea-8f63-c9f01110dd4a.png)

## Mobile

![localhost_3000_schedule(iPhone 6_7_8)](https://user-images.githubusercontent.com/1448289/73117804-fd91e100-3eff-11ea-9ae8-189776b4a4d6.png)
![localhost_3000_schedule(iPad)](https://user-images.githubusercontent.com/1448289/73117805-fe2a7780-3eff-11ea-9bde-c11aff82b383.png)
![localhost_3000_schedule(iPhone 5_SE) (2)](https://user-images.githubusercontent.com/1448289/73117806-fe2a7780-3eff-11ea-92e1-a8f2c2d6b4a5.png)
![localhost_3000_schedule(Pixel 2) (3)](https://user-images.githubusercontent.com/1448289/73117807-fe2a7780-3eff-11ea-94b4-efd8150ec01e.png)
