### PR TITLE
Schedule page data

### DIFF
--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -160,8 +160,7 @@ const textNavItems: {
   label: string;
   link?: string;
 }[] = [
-  /* { label: "News", link: "/news" }, */
-  /*{ label: "Schedule", link: "/schedule" },*/
+  { label: "Schedule", link: "/schedule" },
   { label: "Speakers", link: "/speakers" },
   {
     label: "About",
@@ -175,11 +174,11 @@ const iconNavItems: {
   url?: string;
   external?: boolean;
 }[] = [
-  /*{
+  {
     Icon: FaRegCalendarAlt,
     label: "Schedule",
     url: "/schedule"
-  },*/
+  },
   {
     Icon: FaQuestionCircle,
     label: "About",

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -173,15 +173,15 @@ const iconNavItems: {
     url: "/schedule"
   },
   {
+    Icon: FaQuestionCircle,
+    label: "About",
+    url: "/about"
+  },
+  {
     Icon: FaMapMarkerAlt,
     label: "Venue",
     url: "https://goo.gl/maps/uvivRUCkjAmC5Jqo6",
     external: true
-  },
-  {
-    Icon: FaQuestionCircle,
-    label: "About",
-    url: "/about"
   },
   /*{
     Icon: FaDiscord,

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -163,9 +163,9 @@ const iconNavItems: {
   external?: boolean;
 }[] = [
   {
-    Icon: FaQuestionCircle,
-    label: "About",
-    url: "/about"
+    Icon: GoPerson,
+    label: "Speakers",
+    url: "/speakers"
   },
   {
     Icon: FaRegCalendarAlt,
@@ -173,15 +173,15 @@ const iconNavItems: {
     url: "/schedule"
   },
   {
-    Icon: GoPerson,
-    label: "Speakers",
-    url: "/speakers"
-  },
-  {
     Icon: FaMapMarkerAlt,
     label: "Venue",
     url: "https://goo.gl/maps/uvivRUCkjAmC5Jqo6",
     external: true
+  },
+  {
+    Icon: FaQuestionCircle,
+    label: "About",
+    url: "/about"
   },
   /*{
     Icon: FaDiscord,

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -156,18 +156,6 @@ const Logo = styled.img`
   margin: 0 15px;
 `;
 
-const textNavItems: {
-  label: string;
-  link?: string;
-}[] = [
-  { label: "Schedule", link: "/schedule" },
-  { label: "Speakers", link: "/speakers" },
-  {
-    label: "About",
-    link: "/about"
-  }
-];
-
 const iconNavItems: {
   Icon: IconType;
   label?: string;
@@ -175,14 +163,14 @@ const iconNavItems: {
   external?: boolean;
 }[] = [
   {
-    Icon: FaRegCalendarAlt,
-    label: "Schedule",
-    url: "/schedule"
-  },
-  {
     Icon: FaQuestionCircle,
     label: "About",
     url: "/about"
+  },
+  {
+    Icon: FaRegCalendarAlt,
+    label: "Schedule",
+    url: "/schedule"
   },
   {
     Icon: GoPerson,

--- a/pages/schedule.tsx
+++ b/pages/schedule.tsx
@@ -2,59 +2,56 @@ import { FC, ReactNode } from "react";
 import styled from "styled-components";
 import { NavBar, navbarBlue } from "../components";
 
-import { schedule } from '../data/schedule';
+import { schedule } from "../data/schedule";
 
 const title = "Schedule";
 
 const SchedulePage: FC = () => (
   <>
-  <Background />
-  <NavBar title={title} backgroundColor={navbarBlue} bottom />
-  <Container>
-    <Headline>{title}</Headline>
-    <Schedule>
-      {schedule.map((item, index) => {
+    <Background />
+    <NavBar title={title} backgroundColor={navbarBlue} bottom />
+    <Container>
+      <Headline>{title}</Headline>
+      <Schedule>
+        {schedule.map((item, index) => {
+          let title = <ScheduleItemTitle>{item.title}</ScheduleItemTitle>;
 
-        let title = (
-          <ScheduleItemTitle>{item.title}</ScheduleItemTitle>
-        );
+          let description;
+          if (item.description) {
+            description = (
+              <ScheduleItemDescription>
+                {item.description}
+              </ScheduleItemDescription>
+            );
+          }
 
-        let description;
-        if (item.description) {
-          description = (
-            <ScheduleItemDescription>{item.description}</ScheduleItemDescription>
-          )
-        }
+          let itemContent = (
+            <>
+              {title}
+              {description}
+            </>
+          );
+          if (item.link) {
+            itemContent = (
+              <ScheduleLink href={item.link}>{itemContent}</ScheduleLink>
+            );
+          }
 
-        let itemContent = (
-          <>
-            {title}
-            {description}
-          </>
-        );
-        if (item.link) {
-          itemContent = (
-            <ScheduleLink href={item.link}>
-              {itemContent}
-            </ScheduleLink>
-          )
-        }
+          let itemJsx = (
+            <ScheduleItem key={index}>
+              <ScheduleItemTimeDesktop>{item.time}</ScheduleItemTimeDesktop>
+              <ScheduleItemCircle />
+              <ScheduleItemContent>
+                <ScheduleItemTimeMobile>{item.time}</ScheduleItemTimeMobile>
+                {itemContent}
+              </ScheduleItemContent>
+            </ScheduleItem>
+          );
 
-        let itemJsx = (
-          <ScheduleItem key={index}>
-            <ScheduleItemTimeDesktop>{item.time}</ScheduleItemTimeDesktop>
-            <ScheduleItemCircle />
-            <ScheduleItemContent>
-              <ScheduleItemTimeMobile>{item.time}</ScheduleItemTimeMobile>
-              {itemContent}
-            </ScheduleItemContent>
-          </ScheduleItem>
-        );
-
-        return itemJsx;
-      })}
-    </Schedule>
-  </Container>
+          return itemJsx;
+        })}
+      </Schedule>
+    </Container>
   </>
 );
 
@@ -91,7 +88,8 @@ export const Container = styled.div`
 export const Schedule = styled.ul`
   margin-left: auto;
   margin-right: auto;
-  max-width: 700px;
+  margin-top: 25px;
+  max-width: 900px;
   list-style-type: none;
   padding: 0px;
   padding-left: 0px;
@@ -100,14 +98,14 @@ export const Schedule = styled.ul`
 export const ScheduleItem = styled.li`
   display: flex;
   flex-direction: row;
- 
+
   padding-left: 10px;
-  margin-bottom: 10px;
+  margin-bottom: 0;
 `;
 
 export const ScheduleItemTimeDesktop = styled.p`
   font-size: 1em;
-  color: #FFFFFF;
+  color: #ffffff;
   margin: -1px calc(2vw + 5px) 0 0;
   width: 60px;
   @media screen and (max-width: 500px) {
@@ -118,7 +116,7 @@ export const ScheduleItemTimeDesktop = styled.p`
 export const ScheduleItemTimeMobile = styled.p`
   font-size: 1em;
   font-weight: 700;
-  color: #FFFFFF;
+  color: #ffffff;
   width: 60px;
   line-height: 1.7;
   padding-left: 5px;
@@ -142,7 +140,7 @@ const ScheduleItemCircle = styled.div`
 
 export const ScheduleItemContent = styled.div`
   break-inside: avoid;
-  max-width: 600px;
+  max-width: 900px;
   flex: 1;
   border-left: 2px dashed rgba(255, 255, 255, 0.15);
   padding-left: calc(3vw + 10px);
@@ -154,33 +152,35 @@ export const ScheduleItemContent = styled.div`
 
 export const ScheduleItemTitle = styled.h2`
   font-size: 1.3em;
-  margin-top: 0;
+  margin-top: 5px;
   padding-left: 5px;
   font-weight: normal;
   text-shadow: 2px 4px 5px hsla(237, 80%, 35%, 0.3);
+
+  @media screen and (max-width: 500px) {
+    font-size: 1.3em;
+    font-weight: 700;
+  }
 `;
 
 export const ScheduleItemDescription = styled.p`
   font-size: 1.5em;
-  margin-top: 0px;
-  margin-bottom: 15px;
+  margin-top: 0;
+  margin-bottom: 25px;
   padding: 0 15px 0 5px;
   font-weight: 700;
   text-shadow: 2px 4px 5px hsla(237, 80%, 35%, 0.3);
 
   @media screen and (max-width: 500px) {
-    font-size: 1.4em;
+    font-size: 1.3em;
     font-weight: normal;
   }
 `;
 
 export const ScheduleLink = styled.a`
-  color: #FFFFFF;
+  color: #ffffff;
 
   :hover {
     text-decoration: underline;
   }
 `;
-
-
-


### PR DESCRIPTION
I've added the schedule menu bar item #110  + put minor layout fine tuning in the same PR to shorten the PR process that between timezones can take a day per PR since @surma wants to announce today.

- added the schedule button to the navigation bar
- fine tuning design of schedule page
  - speaker names bold on mobile for better visual orientation
  - schedule on desktop screens a bit wider to break more naturally
  - spacings slightly increased between schedule items to better group visually

<img width="278" alt="Bildschirmfoto 2020-01-25 um 16 00 11" src="https://user-images.githubusercontent.com/347722/73123059-cff27980-3f8b-11ea-8186-e97108a74cc4.png">
<img width="1440" alt="Bildschirmfoto 2020-01-25 um 16 02 17" src="https://user-images.githubusercontent.com/347722/73123086-1e077d00-3f8c-11ea-92a5-19b8f5358f90.png">
