### PR TITLE
Added the youtube Livestream link

### DIFF
--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -189,16 +189,18 @@ const iconNavItems: {
     url: "http://discordapp.com/invite/nEFErF8",
     external: true
   },*/
-  {
+  /* {
     Icon: FaTwitter,
     label: "Twitter",
     url: "https://twitter.com/search?q=%23WasmSummit&src=typed_query",
     external: true
-  }
-  /* {
-    Icon: FaYoutube,
-    label: "Youtube"
   } */
+  {
+    Icon: FaYoutube,
+    label: "Livestream",
+    url: "https://youtu.be/WZp0sPDvWfw",
+    external: true
+  }
 ];
 
 const HomeButton = styled.div`

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -22,11 +22,21 @@ const LandingPage: FC = () => (
           </Subheadline>
         </Title>
       </Hero>
+
       <Oneliner>
         A <OnelinerHighlight>one day, single track</OnelinerHighlight>,
         conference about <OnelinerHighlight>all things</OnelinerHighlight>{" "}
         WebAssembly.
       </Oneliner>
+
+      <CallToAction>
+        <Button
+          primary
+          href="https://youtu.be/WZp0sPDvWfw"
+        >
+          Livestream
+        </Button>
+      </CallToAction>
     </Container>
   </View>
 );
@@ -162,6 +172,10 @@ const Oneliner = styled.div`
     font-size: 1rem;
   }
 
+  @media (max-width: 350px) {
+    display: none;
+  }
+
   @media (max-width: 1024px) and (orientation: portrait) {
     margin-top: 0;
   }
@@ -183,3 +197,31 @@ const OnelinerHighlight = styled.span`
     font-size: 1.1rem;
   }
 `;
+
+const CallToAction = styled.div`
+  margin: 0 auto;
+  text-align: center;
+`;
+
+    const Button = styled.a`
+  font-size: 1.6rem;
+  padding: 15px 20px;
+  background: ${(props: { primary?: boolean }) =>
+    props.primary ? "#2D16A4" : "#fff"};
+  box-shadow: 2px 4px 10px rgba(0, 0, 0, 0.2);
+  border-radius: 5px;
+  margin: 4vh 20px;
+  color: ${(props: { primary?: boolean }) =>
+    props.primary ? "#fff" : "#2D16A4"};
+  transition: all 0.1s ease;
+  display: inline-block;
+  &:hover {
+    box-shadow: 0px 4px 20px rgba(0, 0, 0, 0.2);
+    transform: scale(1.07);
+  }
+  @media (max-width: 768px) {
+    padding: 10px 20px;
+    margin: 10px 5px;
+  }
+`;
+


### PR DESCRIPTION
closes #113 

This adds a button on the landing page per @ttraenkler suggestion, and I also added it on the navbar, in place of the twitter nav item :smile: 

# Screenshots

![Screenshot from 2020-02-09 14-30-49](https://user-images.githubusercontent.com/1448289/74111332-c7cc3980-4b48-11ea-8fcb-15d2db919210.png)

![Screenshot from 2020-02-09 14-23-38](https://user-images.githubusercontent.com/1448289/74111263-4d031e80-4b48-11ea-8136-22b76b919c7d.png)
![Screenshot from 2020-02-09 14-23-33](https://user-images.githubusercontent.com/1448289/74111264-4d9bb500-4b48-11ea-8aee-a82b43a5c3bc.png)
![Screenshot from 2020-02-09 14-23-13](https://user-images.githubusercontent.com/1448289/74111266-4ecce200-4b48-11ea-93a9-344bfc4b2d81.png)
