### PR TITLE
Feature/118 embed video recordings

### DIFF
--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -164,7 +164,7 @@ const iconNavItems: {
 }[] = [
   {
     Icon: GoPerson,
-    label: "Speakers",
+    label: "Talks",
     url: "/speakers"
   },
   {
@@ -183,24 +183,24 @@ const iconNavItems: {
     url: "https://goo.gl/maps/uvivRUCkjAmC5Jqo6",
     external: true
   },
-  /*{
+  {
     Icon: FaDiscord,
     label: "Chat",
     url: "http://discordapp.com/invite/nEFErF8",
     external: true
-  },*/
+  }
   /* {
     Icon: FaTwitter,
     label: "Twitter",
     url: "https://twitter.com/search?q=%23WasmSummit&src=typed_query",
     external: true
   } */
-  {
+  /*  {
     Icon: FaYoutube,
-    label: "Livestream",
+    label: "Videos",
     url: "https://youtu.be/WZp0sPDvWfw",
     external: true
-  }
+  }*/
 ];
 
 const HomeButton = styled.div`

--- a/components/SpeakerCard.tsx
+++ b/components/SpeakerCard.tsx
@@ -3,6 +3,9 @@ import styled from "styled-components";
 import { wasmPurple } from "./colors";
 
 export const SpeakerSummary = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
   padding: 15px 30px 30px 30px;
   background: hsl(239, 50%, 25%);
   height: 140px;
@@ -91,7 +94,8 @@ export const Title = styled.h2`
   font-weight: normal;
   margin: 0px 0;
   padding: 0;
-  color: rgba(255, 255, 255, 0.85);
+  flex: 1;
+  color: rgba(255, 255, 255, 1);
 
   @media screen and (max-width: 1280px) {
     font-size: 1.27em;

--- a/data/talks.tsx
+++ b/data/talks.tsx
@@ -1,5 +1,9 @@
 import { ReactNode } from "react";
+import styled from "styled-components";
 
+const SmallFont = styled.span`
+  font-size: 0.8em;
+`;
 export type Talk = {
   speakerId?: string;
   title?: ReactNode;

--- a/data/talks.tsx
+++ b/data/talks.tsx
@@ -8,16 +8,19 @@ export type Talk = {
     end?: string;
   };
   abstract?: ReactNode;
+  embedId?: string;
 };
 
 export const talks: { [id: string]: Talk } = {
   "1": {
     speakerId: "1",
-    title: "Opening Keynote"
+    title: "Opening Keynote",
+    embedId: "IBZFJzGnBoU"
   },
   "2": {
     speakerId: "2",
     title: "Shipping Tiny WebAssembly Builds",
+    embedId: "_lLqZR4ufSI",
     abstract:
       "Code size matters in many places, especially (but not only!) on the Web. This talk will present current best practices in generating small WebAssembly builds when using popular toolchains like LLVM, Emscripten, Rust, Go, and AssemblyScript."
   },
@@ -25,6 +28,7 @@ export const talks: { [id: string]: Talk } = {
     speakerId: "3",
     title:
       "Why the #wasmsummit Website isn't written in Wasm, and what that means for the future of Wasm",
+    embedId: "J5Rs9oG3FdI",
     abstract: (
       <>
         <p>
@@ -57,12 +61,14 @@ export const talks: { [id: string]: Talk } = {
   "4": {
     speakerId: "4",
     title: "JavaScriptCore's new WebAssembly interpreter",
+    embedId: "1v4wPoMskfo",
     abstract:
       "In this talk, we will look at JavaScriptCore's newest WebAssembly tier, the Low Level Interpreter (LLInt). With the addition of the interpreter, JavaScriptCore now uses three tiers to execute WebAssembly: LLInt, BBQ and OMG. Because of the new interpreter, WebAssembly programs executing in JavaScriptCore now start up 3x faster. Because of the three-tiered approach, we were able to achieve this while maintaining the same throughput performance."
   },
   "5": {
     speakerId: "5",
     title: "WebAssembly Music",
+    embedId: "C8j_ieOm4vE",
     abstract:
       "Been playing with computer music since the 80s from the tracker era to modern soft synths and DAWs, and even writing some myself. Recently as WebAssembly  came along with excellent performance, and AudioWorklet technology in  providing low latency audio, it's finally possible to use the web for serious music production. As a programmer I like to use a programming language for expressing the music, and also for synthesizing the instruments. I compose my music in Javascript and create my instruments in AssemblyScript which is compiled to WebAssembly. It's all running in the browser. You can write the music in a live coding-environment, and you can play and record the instruments with a midi-keyboard."
   },
@@ -70,23 +76,27 @@ export const talks: { [id: string]: Talk } = {
     speakerId: "6",
     title:
       "Making it easier to make Things: WebAssembly and the Internet of Things",
+    embedId: "oky3FdsTuUM",
     abstract:
       "WebAssembly is moving beyond the browser - but is it ready for IoT apps and tiny embedded devices? Yes...ish. In this talk, learn about the state of running Wasm on embedded devices (as low as 512kb of RAM & 64 MHz) and what's left to solve. Also learn where Wasm can today help with IoT protocols and tools."
   },
   "7": {
     speakerId: "7",
     title: "Building a Containerless Future with WebAssembly",
+    embedId: "vqBtoPJoQOE",
     abstract:
       "WebAssembly is the future of distributed computing. Its security, memory isolation, small footprint, and true portability are all advantages on the web, but become truly game-changing when used to build functions and services deployed in the cloud. This session illustrates how to host WebAssembly modules in Rust code, how to build modules in many different languages (including pros and cons of each), and how to securely grant cloud-native capabilities to these modules. Discussed in detail is the current state of the art in WebAssembly and what can be built with it today. Learn what developers can start doing now to build the containerless future where WebAssembly modules are the de-facto unit of immutable deployment in the cloud, at the edge, and even in IoT and embedded devices."
   },
   "8": {
     speakerId: "8",
     title: "WebAssembly as a <video> polyfill",
+    embedId: "rGhasYrH5Vo",
     abstract:
       "An introduction to Wikipedia's ogv.js media compatibility shim, which uses WebAssembly codecs to provide video file format compatibility for VP9 and AV1 video in browsers that don't play them natively. Will explore the division between the JS and Wasm parts of the code base, and how advances in emscripten and LLVM create opportunities and challenges for performance as different browsers implement different levels of the spec (threading, SIMD, etc)."
   },
   "9": {
     speakerId: "9",
+    embedId: "ptAhZLn9waI",
     title: "Closing Keynote"
   }
 };

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -32,7 +32,7 @@ const LandingPage: FC = () => (
       </Oneliner>
 
       <CallToAction>
-        <Button primary href="https://youtu.be/WZp0sPDvWfw">
+        <Button primary href="https://www.youtube.com/playlist?list=PL6ed-L7Ni0yQ1pCKkw1g3QeN2BQxXvCPK">
           Watch the talks
         </Button>
         <Button href="https://photos.google.com/share/AF1QipPBVFpXLx0OVpyk0U4KhddBE-69EXulgSEzLq8E5RYlkUvqDtsxL-xF1SdgBG5UUA?key=Q1c2cHlSS2RWNFZBVE9DOVhSamw4WXoxYThnU2l3">

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -33,9 +33,9 @@ const LandingPage: FC = () => (
 
       <CallToAction>
         <Button primary href="https://youtu.be/WZp0sPDvWfw">
-          Watch the recording
+          Watch the talks
         </Button>
-        <Button primary href="https://photos.google.com/share/AF1QipPBVFpXLx0OVpyk0U4KhddBE-69EXulgSEzLq8E5RYlkUvqDtsxL-xF1SdgBG5UUA?key=Q1c2cHlSS2RWNFZBVE9DOVhSamw4WXoxYThnU2l3">
+        <Button href="https://photos.google.com/share/AF1QipPBVFpXLx0OVpyk0U4KhddBE-69EXulgSEzLq8E5RYlkUvqDtsxL-xF1SdgBG5UUA?key=Q1c2cHlSS2RWNFZBVE9DOVhSamw4WXoxYThnU2l3">
           See the photos
         </Button>
       </CallToAction>

--- a/pages/speakers/[id].tsx
+++ b/pages/speakers/[id].tsx
@@ -36,48 +36,28 @@ const SpeakerPage: FC = () => {
       <Background />
       <NavBar title={title} backgroundColor={navbarBlue} bottom />
       <Content>
-        {/* <PageTitle>{title}</PageTitle> */}
-        <Columns>
-          <SpeakerBox>
-            {speaker.name && (
+        <Section>
+          <Headline>
+            {speaker.name}{" "}
+            {speaker.website && (
               <a href={speaker.website} target="_blank">
-                <SpeakerCard>
-                  <img
-                    src={speaker.picture}
-                    alt={`picture of ${speaker.name}`}
-                  ></img>
-                  <SpeakerName>
-                    <strong>{speaker.name}</strong>{" "}
-                    {speaker.company && <Company>{speaker.company}</Company>}
-                  </SpeakerName>
-                  <SpeakerSummary>
-                    {speaker.website && (
-                      <>
-                        <Links>
-                          <Icon>
-                            <LinkIcon size={32}></LinkIcon>
-                          </Icon>
-                        </Links>
-                      </>
-                    )}
-                  </SpeakerSummary>
-                </SpeakerCard>
+                <Icon>
+                  <LinkIcon size={25}></LinkIcon>
+                </Icon>
               </a>
             )}
-          </SpeakerBox>
-          <Section>
-            {speaker.name && <SectionHeading>{talk.title}</SectionHeading>}
-            <SectionSubHeading>
-              {talk.time &&
-                talk.time.start &&
-                talk.time.end &&
-                `${talk.time && talk.time.start} - ${talk.time &&
+          </Headline>
+          <SpeakerNameHeadline>{talk.title}</SpeakerNameHeadline>
+          {talk.time && talk.time.start && talk.time.end && (
+            <SectionHeading>
+              {" "}
+              {`${talk.time && talk.time.start} - ${talk.time &&
                 talk.time.end}`}
-            </SectionSubHeading>
-            <YoutubeEmbed embedId={talk.embedId} />
-            <SectionContent>{talk.abstract}</SectionContent>
-          </Section>
-        </Columns>
+            </SectionHeading>
+          )}
+          <YoutubeEmbed embedId={talk.embedId} />
+          <SectionContent>{talk.abstract}</SectionContent>
+        </Section>
       </Content>
     </>
   );
@@ -85,16 +65,35 @@ const SpeakerPage: FC = () => {
 
 const YoutubeEmbed: FC<{ embedId: string }> = ({ embedId }) => {
   return (
-    <iframe
-      width="100%"
-      height="450"
-      style={{ marginBottom: "20px" }}
-      src={`https://www.youtube.com/embed/${embedId}?list=PL6ed-L7Ni0yQ1pCKkw1g3QeN2BQxXvCPK`}
-      frameBorder="0"
-      allowFullScreen
-      allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" ></iframe >
-  )
-}
+    <div
+      style={{
+        position: "relative",
+        width: "97%",
+        paddingTop: "53.25%",
+        margin: "50px 10px"
+      }}
+    >
+      <iframe
+        style={{
+          position: "absolute",
+          top: 0,
+          bottom: 0,
+          left: 0,
+          right: 0,
+          border: "1px solid black",
+          boxShadow: "5px 10px 15px rgba(0,0,0,0.5)",
+          borderRadius: 10
+        }}
+        width={"100%"}
+        height={"100%"}
+        src={`https://www.youtube.com/embed/${embedId}?list=PL6ed-L7Ni0yQ1pCKkw1g3QeN2BQxXvCPK`}
+        frameBorder={0}
+        allowFullScreen
+        allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+      ></iframe>
+    </div>
+  );
+};
 
 export default SpeakerPage;
 
@@ -102,15 +101,19 @@ const Links = styled.div`
   display: flex;
   flex-direction: row;
   align-items: center;
-  justify-content: flex-end;
+  justify-content: flex-start;
+  margin-left: 5px;
 `;
 
-export const Icon = styled.div`
-  padding: 0 10px;
-  color: rgba(255, 255, 255, 0.8);
-`;
+export const Icon = styled.span`
+  padding: 5px 10px;
+  color: rgba(255, 255, 255, 0.7);
+  transition: 150ms;
 
-const Time = styled.div``;
+  &:hover {
+    color: white;
+  }
+`;
 
 const Background = styled.div`
   display: flex;
@@ -122,20 +125,6 @@ const Background = styled.div`
   background-color: hsla(237, 0%, 48%, 0.15);
   padding: 25px;
   z-index: -1;
-`;
-
-const SpeakerBox = styled.div`
-  display: flex;
-  flex-direction: column;
-  margin-top: 0vh;
-  margin-bottom: 2vh;
-  margin-right: 0;
-  padding-top: 0;
-
-  @media screen and (max-width: 450px) {
-    /* display: none; */
-    margin-top: 3vh;
-  }
 `;
 
 export const PageTitle = styled.h1`
@@ -154,43 +143,39 @@ export const PageTitle = styled.h1`
 
 export const Headline = styled.h2`
   font-size: 2em;
+  margin: 0;
+
   margin-top: 3vh;
   margin-bottom: 0vh;
   padding: 0 15px;
 
   @media screen and (max-width: 1024px) {
-    font-size: 2em;
+    font-size: 1.9em;
   }
 `;
 
 const Content = styled.div`
   display: flex;
   flex-direction: row;
-  padding: 3vh 3vw;
+  flex-wrap: wrap;
+  padding: 1vh 3vw;
   color: white;
   min-height: calc(100vh - 65px);
-  align-items: center;
-  justify-content: center;
-`;
-
-const Columns = styled.div`
-  background-color: ${(props: { primary?: boolean }) =>
-    props.primary ? "#fff" : "transparent"};
-  box-shadow: ${(props: { primary?: boolean }) =>
-    props.primary ? "0px 5px 30px rgba(0,0,0,0.01)" : "0px"};
-  color: #fff;
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-  justify-content: center;
   align-items: flex-start;
+  justify-content: center;
+  padding-bottom: 70px;
+
+  @media screen and (orientation: portrait) {
+    flex-direction: row;
+  }
 `;
 
 const Section = styled.div`
+  margin-top: 3vh;
   break-inside: avoid;
-  flex: 1;
-  margin: 1vh 3vw 0vh 3vw;
+  flex: 2;
   max-width: 1024px;
+  min-width: 350px;
 `;
 
 const SectionHeading = styled.h2`
@@ -206,46 +191,52 @@ const SectionHeading = styled.h2`
   }
 `;
 
-const SectionSubHeading = styled.p`
-  font-size: 1.3em;
-  margin: 0 25px 0 0;
-  padding: 15px;
-  font-weight: 700;
-  text-shadow: 2px 4px 5px hsla(237, 80%, 35%, 0.3);
-`;
-
 const SectionContent = styled.div`
-  font-size: 1.2em;
-  margin: 0 0px 0 0;
-  padding: 0 15px 50px 25px;
+  font-size: 1.3em;
+  margin: 5vh 15px 3vh 15px;
+  /*   padding: 0 15px 50px 25px;
+ */
   line-height: 1.8;
   color: rgba(255, 255, 255, 0.9);
   text-shadow: 1px 4px 10px rgba(0, 0, 0, 0.25);
   font-weight: ${(props: { bold?: boolean }) => (props.bold ? 700 : "normal")};
 `;
 
+const SpeakerNameHeadline = styled.h2`
+  font-size: 1.5em;
+  padding-bottom: 15px;
+  padding-left: 15px;
+  font-weight: 700;
+  border-bottom: 3px solid rgba(255, 255, 255, 0.4);
+  text-shadow: 2px 4px 5px hsla(237, 80%, 35%, 0.3);
+
+  @media screen and (max-width: 1024px) {
+    font-size: 1.3em;
+  }
+`;
+
 export const SpeakerSummary = styled.div`
-  padding: 15px 30px 30px 30px;
-  background: hsl(239, 50%, 25%);
-  height: 40px;
-  line-height: 1.8;
-  font-size: 0.78em;
   display: flex;
   flex-direction: column;
-  justify-content: flex-end;
+  justify-content: center;
+  padding: 15px 30px 30px 30px;
+  background: hsl(239, 50%, 25%);
+  height: 130px;
+  line-height: 1.8;
+  font-size: 1em;
 
   p {
     color: rgba(255, 255, 255, 0.5);
     margin: 0;
     margin-bottom: 5px;
     font-weight: normal;
-    font-size: 1.4em;
+    font-size: 1.8em;
     padding: 0;
   }
 
   @media (max-width: 1280px) {
     padding: 15px 25px;
-    height: 50px;
+    height: 130px;
     line-height: 1.6;
   }
   color: rgba(255, 255, 255, 0.8);

--- a/pages/speakers/[id].tsx
+++ b/pages/speakers/[id].tsx
@@ -72,9 +72,9 @@ const SpeakerPage: FC = () => {
                 talk.time.start &&
                 talk.time.end &&
                 `${talk.time && talk.time.start} - ${talk.time &&
-                  talk.time.end}`}
+                talk.time.end}`}
             </SectionSubHeading>
-
+            <YoutubeEmbed embedId={talk.embedId} />
             <SectionContent>{talk.abstract}</SectionContent>
           </Section>
         </Columns>
@@ -82,6 +82,19 @@ const SpeakerPage: FC = () => {
     </>
   );
 };
+
+const YoutubeEmbed: FC<{ embedId: string }> = ({ embedId }) => {
+  return (
+    <iframe
+      width="100%"
+      height="450"
+      style={{ marginBottom: "20px" }}
+      src={`https://www.youtube.com/embed/${embedId}?list=PL6ed-L7Ni0yQ1pCKkw1g3QeN2BQxXvCPK`}
+      frameBorder="0"
+      allowFullScreen
+      allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" ></iframe >
+  )
+}
 
 export default SpeakerPage;
 


### PR DESCRIPTION
Solves #118.

- fixed collapsing layout of speaker page where the video of the keynote talks was cutoff
- removed speaker card from speaker page in favour of embedded video
- fixed mobile layout of embedded video
- moved speaker name, title, and link are part of the headline
- replaced "Livestream" link in navbar with "Chat" since it was redundant
- renamed "Speakers" link in navbar to "Talks" while not renaming the /speakers route to not break existing external links
- renamed "Watch the recording" to "Watch the talks"

screenshots:
<img width="1440" alt="Bildschirmfoto 2020-02-27 um 14 47 35" src="https://user-images.githubusercontent.com/347722/75451336-b2d90e00-5970-11ea-8e32-303a278ff68d.png">
<img width="1440" alt="Bildschirmfoto 2020-02-27 um 14 47 17" src="https://user-images.githubusercontent.com/347722/75451350-b8365880-5970-11ea-98a7-3e3a8b75432b.png">
<img width="1345" alt="Bildschirmfoto 2020-02-27 um 14 46 54" src="https://user-images.githubusercontent.com/347722/75451360-ba98b280-5970-11ea-8fe9-c56fe616e171.png">
<img width="449" alt="Bildschirmfoto 2020-02-27 um 14 52 10" src="https://user-images.githubusercontent.com/347722/75451377-c1bfc080-5970-11ea-9e4d-62fab6be71bb.png">
