### PR TITLE
Added a Code of Conduct Page, and Stand-in Code of Conduct from last year

### DIFF
--- a/_includes/default.ejs
+++ b/_includes/default.ejs
@@ -162,6 +162,7 @@
 <header>
   <a href="/">Home</a>
   <a href="/faq">FAQ</a>
+  <a href="/coc">Code of Conduct</a>
 </header>
 <main lang="en">
   <%- content %>

--- a/src/coc.md
+++ b/src/coc.md
@@ -3,4 +3,20 @@ layout: default.ejs
 permalink: coc.html
 ---
 
-The code of conduct for WebAssembly Summit can be found [here](https://github.com/WebAssemblySummit/webassembly-summit.org/blob/68e669d279ece17af2466534096f71094034ea60/CODE_OF_CONDUCT.md). This Code of Conduct is subject to change to better align with the virtual WebAssembly Summit in 2021.
+<style>
+  main {
+    max-width: 900px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  main a {
+    color: var(--off-white);
+  }
+
+  main a:visited {
+    color: var(--purple);
+  }
+</style>
+
+WebAssembly Summit is intended to be an inclusive, welcoming conference for everyone. The code of conduct for WebAssembly Summit can be found [here](https://github.com/WebAssemblySummit/webassembly-summit.org/blob/68e669d279ece17af2466534096f71094034ea60/CODE_OF_CONDUCT.md). This Code of Conduct is subject to change to better align with the virtual WebAssembly Summit in 2021.

--- a/src/coc.md
+++ b/src/coc.md
@@ -1,0 +1,6 @@
+---
+layout: default.ejs
+permalink: coc.html
+---
+
+The code of conduct for WebAssembly Summit can be found [here](https://github.com/WebAssemblySummit/webassembly-summit.org/blob/68e669d279ece17af2466534096f71094034ea60/CODE_OF_CONDUCT.md). This Code of Conduct is subject to change to better align with the virtual WebAssembly Summit in 2021.


### PR DESCRIPTION
As the title states :smile: 

I've actually never used Eleventy before, I feel like it may be worth applying the styles from #123 in a place so they can be shared. But yeah :smile: Worse case scenario, we can merge both, and then hoist it up somewhere after :smile: 

(Also, while we are here. Is the off-white text okay for a11y contrast ratios? I can't seem to figure out how to get that to show in devtools anymore :thinking: )

![Screenshot from 2020-11-25 17-51-22](https://user-images.githubusercontent.com/1448289/100298908-2b441e00-2f47-11eb-9e97-567647faf225.png)
