### PR TITLE
Updated the Code of Conduct for a Virtual Setting

### DIFF
--- a/src/coc.md
+++ b/src/coc.md
@@ -19,4 +19,32 @@ permalink: coc.html
   }
 </style>
 
-WebAssembly Summit is intended to be an inclusive, welcoming conference for everyone. The code of conduct for WebAssembly Summit can be found [here](https://github.com/WebAssemblySummit/webassembly-summit.org/blob/68e669d279ece17af2466534096f71094034ea60/CODE_OF_CONDUCT.md). This Code of Conduct is subject to change to better align with the virtual WebAssembly Summit in 2021.
+# Code of Conduct
+
+This code of conduct governs this repo, the organizers and organizers' communication
+channels, as well as the event.
+
+We draw heavily from the [RustConf Code of Conduct](https://rustconf.com/about/#code-of-conduct), and the [CascadiaJS 2020 Code of Conduct](https://2020.cascadiajs.com/coc).
+
+## WebAssembly Summit is intended to be an inclusive, welcoming conference for everyone.
+
+In particular, we do not tolerate harassment of conference participants or organizers in any form. Conference participants and organizers violating these rules may be sanctioned or expelled from the conference at the discretion of the conference organizers.
+
+## Who does the Code of Conduct apply to?
+
+Everyone - including attendees, sponsors, speakers, and organizers - is required to agree to and follow this Code of Conduct. Inappropriate behavior or harassment of any kind is not tolerated. Organizers will enforce this code with any event involvement, including, but not limited to: online engagement (Twitter/Discord), or any WebAssembly Summit hosted event.
+
+## What constitutes a Code of Conduct violation?
+
+Harassment, including disparaging verbal comments related to gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, age, or religion; sexual images in public spaces; deliberate intimidation; stalking; sustained disruption of talks or other events; inappropriate physical contact; and unwelcome sexual attention. Participants and organizers asked to stop any harassing behavior are expected to comply immediately.
+
+If a participant or organizer engages in harassing behavior, the conference organizers may take any action they deem appropriate, including warning the offender or expulsion from the conference with no refund. If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of conference staff immediately.
+
+## Repoting Code of Conduct Issues
+
+If you need help of any kind, to report a bad situation, or anything else not specified that we can help with, please DM us on Twitter or Discord.
+
+Organizers contact info:
+
+- Aaron Turner, Twitter: [@torch2424](https://twitter.com/torch2424), Discord: torch2424#4615
+- Surma, [@dassurma](https://twitter.com/DasSurma), Discord: surma#6368


### PR DESCRIPTION
Hello!

So as we talked about before, I went ahead and updated the Code of Conduct to better reflect a digital setting. I gave our online contact info (Twitter, and Discord). As well as called out the nature of the Online event. 

I essentially tried to do a merge of CascadiaJS 2020 (Which was virtual), with out existing code of conduct. I put the WIP on this, because I reached out to Carter, the organizer of Cascadia, to ask if it was okay with them if we did this :smile: 

~~So once I hear back from them, this should be good to go!~~ :smile: 

Got the okay! This is good to go! :smile: 

![Screenshot from 2021-04-15 15-39-31](https://user-images.githubusercontent.com/1448289/114946878-e0954680-9e00-11eb-8db3-5a01cf091698.png)
